### PR TITLE
pyGHDL.dom: forward contextItems and generic map to PackageInstantiation

### DIFF
--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -81,22 +81,22 @@ from pyGHDL.dom.Symbol import (
 
 @export
 class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
-    def __init__(self, associationNode: Iir, actual: ExpressionUnion, formal: Symbol = None) -> None:
-        super().__init__(actual, formal)
+    def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
 
 @export
 class PortAssociationItem(VHDLModel_PortAssociationItem, DOMMixin):
-    def __init__(self, associationNode: Iir, actual: ExpressionUnion, formal: Symbol = None) -> None:
-        super().__init__(actual, formal)
+    def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
 
 @export
 class ParameterAssociationItem(VHDLModel_ParameterAssociationItem, DOMMixin):
-    def __init__(self, associationNode: Iir, actual: ExpressionUnion, formal: Symbol = None) -> None:
-        super().__init__(actual, formal)
+    def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
+        super().__init__(formal, actual)
         DOMMixin.__init__(self, associationNode)
 
 

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -107,10 +107,10 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
         instantiationNode: Iir,
         label: str,
         componentSymbol: ComponentInstantiationSymbol,
-        genericAssociations: Iterable[AssociationItem] = None,
-        portAssociations: Iterable[AssociationItem] = None,
+        genericAssociationItems: Iterable[AssociationItem] = None,
+        portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
-        super().__init__(label, componentSymbol, genericAssociations, portAssociations)
+        super().__init__(label, componentSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
     @classmethod
@@ -118,10 +118,10 @@ class ComponentInstantiation(VHDLModel_ComponentInstantiation, DOMMixin):
         from pyGHDL.dom._Translate import GetName, GetGenericMapAspect, GetPortMapAspect
 
         componentSymbol = ComponentInstantiationSymbol(instantiatedUnit, GetName(instantiatedUnit))
-        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
-        portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
+        portAssociationItems = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
 
-        return cls(instantiationNode, label, componentSymbol, genericAssociations, portAssociations)
+        return cls(instantiationNode, label, componentSymbol, genericAssociationItems, portAssociationItems)
 
 
 @export
@@ -132,10 +132,10 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
         label: str,
         entitySymbol: EntityInstantiationSymbol,
         architectureSymbol: ArchitectureSymbol = None,  # TODO: merge both symbols ?
-        genericAssociations: Iterable[AssociationItem] = None,
-        portAssociations: Iterable[AssociationItem] = None,
+        genericAssociationItems: Iterable[AssociationItem] = None,
+        portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
-        super().__init__(label, entitySymbol, architectureSymbol, genericAssociations, portAssociations)
+        super().__init__(label, entitySymbol, architectureSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
     @classmethod
@@ -150,10 +150,10 @@ class EntityInstantiation(VHDLModel_EntityInstantiation, DOMMixin):
         if architectureId != nodes.Null_Iir:
             architectureSymbol = ArchitectureSymbol(GetName(architectureId), entitySymbol)
 
-        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
-        portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
+        portAssociationItems = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
 
-        return cls(instantiationNode, label, entitySymbol, architectureSymbol, genericAssociations, portAssociations)
+        return cls(instantiationNode, label, entitySymbol, architectureSymbol, genericAssociationItems, portAssociationItems)
 
 
 @export
@@ -163,10 +163,10 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
         instantiationNode: Iir,
         label: str,
         configurationSymbol: ConfigurationInstantiationSymbol,
-        genericAssociations: Iterable[AssociationItem] = None,
-        portAssociations: Iterable[AssociationItem] = None,
+        genericAssociationItems: Iterable[AssociationItem] = None,
+        portAssociationItems: Iterable[AssociationItem] = None,
     ) -> None:
-        super().__init__(label, configurationSymbol, genericAssociations, portAssociations)
+        super().__init__(label, configurationSymbol, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, instantiationNode)
 
     @classmethod
@@ -176,10 +176,10 @@ class ConfigurationInstantiation(VHDLModel_ConfigurationInstantiation, DOMMixin)
         configurationName = nodes.Get_Configuration_Name(instantiatedUnit)
         configurationSymbol = ConfigurationInstantiationSymbol(configurationName, GetName(configurationName))
 
-        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
-        portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
+        portAssociationItems = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
 
-        return cls(instantiationNode, label, configurationSymbol, genericAssociations, portAssociations)
+        return cls(instantiationNode, label, configurationSymbol, genericAssociationItems, portAssociationItems)
 
 
 @export
@@ -198,8 +198,8 @@ class ConcurrentBlockStatement(VHDLModel_ConcurrentBlockStatement, DOMMixin):
     def parse(cls, blockNode: Iir, label: str) -> "ConcurrentBlockStatement":
         from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
 
-        #        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
-        #        portAssociations = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
+        #        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
+        #        portAssociationItems = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(instantiationNode))
 
         declaredItems = GetDeclaredItemsFromChainedNodes(nodes.Get_Declaration_Chain(blockNode), "block", label)
         statements = GetConcurrentStatementsFromChainedNodes(
@@ -669,9 +669,9 @@ class ConcurrentProcedureCall(VHDLModel_ConcurrentProcedureCall, DOMMixin):
         callNode: Iir,
         label: str,
         procedureName: Symbol,
-        parameterMappings: Iterable,
+        parameterAssociationItems: Iterable,
     ) -> None:
-        super().__init__(label, procedureName, parameterMappings)
+        super().__init__(label, procedureName, parameterAssociationItems)
         DOMMixin.__init__(self, callNode)
 
     @classmethod

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -295,12 +295,11 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         node: Iir,
         identifier: str,
         uninstantiatedPackageName: Symbol,
-        #        genericItems: List[GenericInterfaceItem] = None,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
-        genericAssociations: Iterable[VHDLModel_GenericAssociationItem] = None,
+        genericItems: Iterable[VHDLModel_GenericAssociationItem] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericAssociations, documentation)
+        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericItems, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -315,11 +314,15 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         # NOTE: Get_Generic_Chain on a package instantiation is only populated after semantic analysis has resolved
         #       and macro-expanded the uninstantiated package (same for Get_Uninstantiated_Package_Decl); since
         #       Document.translate() only parses (see sem_lib.Load_File), that chain is Null_Iir here and the
-        #       generic *declarations* cannot be read at this stage. What is available right now is the generic
-        #       *map* aspect - the associations actually written at the instantiation site (e.g. 'WIDTH => 16').
-        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
+        #       generic *declarations* (what Entity.parse reads as its own 'genericItems', a list of
+        #       GenericInterfaceItemMixin) cannot be read at this stage.
+        #       What is available right now is the generic *map* aspect - the associations actually written at the
+        #       instantiation site (e.g. 'WIDTH => 16'), a list of GenericAssociationItem - that's what genericItems
+        #       holds here.
+        # FIXME: once semantic analysis is available, also read the referenced package's generic declarations.
+        genericItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
 
-        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericAssociations, documentation)
+        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericItems, documentation)
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -296,10 +296,10 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         identifier: str,
         uninstantiatedPackageName: Symbol,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
-        genericItems: Iterable[VHDLModel_GenericAssociationItem] = None,
+        genericMapItems: Iterable[VHDLModel_GenericAssociationItem] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericItems, documentation)
+        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericMapItems, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -317,12 +317,12 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         #       generic *declarations* (what Entity.parse reads as its own 'genericItems', a list of
         #       GenericInterfaceItemMixin) cannot be read at this stage.
         #       What is available right now is the generic *map* aspect - the associations actually written at the
-        #       instantiation site (e.g. 'WIDTH => 16'), a list of GenericAssociationItem - that's what genericItems
-        #       holds here.
+        #       instantiation site (e.g. 'WIDTH => 16'), a list of GenericAssociationItem - that's what
+        #       genericMapItems holds here.
         # FIXME: once semantic analysis is available, also read the referenced package's generic declarations.
-        genericItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
+        genericMapItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
 
-        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericItems, documentation)
+        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericMapItems, documentation)
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -311,15 +311,6 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         )
         uninstantiatedPackageSymbol = PackageReferenceSymbol(uninstantiatedPackageNode, uninstantiatedPackageName)
 
-        # NOTE: Get_Generic_Chain on a package instantiation is only populated after semantic analysis has resolved
-        #       and macro-expanded the uninstantiated package (same for Get_Uninstantiated_Package_Decl); since
-        #       Document.translate() only parses (see sem_lib.Load_File), that chain is Null_Iir here and the
-        #       generic *declarations* (what Entity.parse reads as its own 'genericItems', a list of
-        #       GenericInterfaceItemMixin) cannot be read at this stage.
-        #       What is available right now is the generic *map* aspect - the associations actually written at the
-        #       instantiation site (e.g. 'WIDTH => 16'), a list of GenericAssociationItem - that's what
-        #       genericAssociationItems holds here.
-        # FIXME: once semantic analysis is available, also read the referenced package's generic declarations.
         genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
 
         return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericAssociationItems, documentation)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -296,10 +296,10 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         identifier: str,
         uninstantiatedPackageName: Symbol,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
-        genericMapItems: Iterable[VHDLModel_GenericAssociationItem] = None,
+        genericAssociationItems: Iterable[VHDLModel_GenericAssociationItem] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericMapItems, documentation)
+        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericAssociationItems, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -318,11 +318,11 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         #       GenericInterfaceItemMixin) cannot be read at this stage.
         #       What is available right now is the generic *map* aspect - the associations actually written at the
         #       instantiation site (e.g. 'WIDTH => 16'), a list of GenericAssociationItem - that's what
-        #       genericMapItems holds here.
+        #       genericAssociationItems holds here.
         # FIXME: once semantic analysis is available, also read the referenced package's generic declarations.
-        genericMapItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
 
-        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericMapItems, documentation)
+        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericAssociationItems, documentation)
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -59,13 +59,14 @@ from pyVHDLModel.DesignUnit import LibraryClause as VHDLModel_LibraryClause
 from pyVHDLModel.DesignUnit import UseClause as VHDLModel_UseClause
 from pyVHDLModel.DesignUnit import ContextReference as VHDLModel_ContextReference
 from pyVHDLModel.DesignUnit import ContextUnion as VHDLModel_ContextUnion
+from pyVHDLModel.Association import GenericAssociationItem as VHDLModel_GenericAssociationItem
 
 from pyGHDL.libghdl import utils
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
-from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName
+from pyGHDL.dom._Translate import GetGenericsFromChainedNodes, GetPortsFromChainedNodes, GetName, GetGenericMapAspect
 from pyGHDL.dom._Translate import GetDeclaredItemsFromChainedNodes, GetConcurrentStatementsFromChainedNodes
 from pyGHDL.dom.Name import SimpleName, AllName
 from pyGHDL.dom.Symbol import (
@@ -296,9 +297,10 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         uninstantiatedPackageName: Symbol,
         #        genericItems: List[GenericInterfaceItem] = None,
         contextItems: Iterable[VHDLModel_ContextUnion] = None,
+        genericAssociations: Iterable[VHDLModel_GenericAssociationItem] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, uninstantiatedPackageName, contextItems, documentation)
+        super().__init__(identifier, uninstantiatedPackageName, contextItems, genericAssociations, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -310,11 +312,14 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         )
         uninstantiatedPackageSymbol = PackageReferenceSymbol(uninstantiatedPackageNode, uninstantiatedPackageName)
 
-        # FIXME: read generics
-        # FIXME: read generic map
-        # genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
+        # NOTE: Get_Generic_Chain on a package instantiation is only populated after semantic analysis has resolved
+        #       and macro-expanded the uninstantiated package (same for Get_Uninstantiated_Package_Decl); since
+        #       Document.translate() only parses (see sem_lib.Load_File), that chain is Null_Iir here and the
+        #       generic *declarations* cannot be read at this stage. What is available right now is the generic
+        #       *map* aspect - the associations actually written at the instantiation site (e.g. 'WIDTH => 16').
+        genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(packageNode))
 
-        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, documentation)
+        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, genericAssociations, documentation)
 
 
 @export

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -295,13 +295,14 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         identifier: str,
         uninstantiatedPackageName: Symbol,
         #        genericItems: List[GenericInterfaceItem] = None,
+        contextItems: Iterable[VHDLModel_ContextUnion] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, uninstantiatedPackageName, documentation)
+        super().__init__(identifier, uninstantiatedPackageName, contextItems, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, packageNode: Iir):
+    def parse(cls, packageNode: Iir, contextItems: Iterable[VHDLModel_ContextUnion] = None):
         name = GetNameOfNode(packageNode)
         documentation = GetDocumentationOfNode(packageNode)
         uninstantiatedPackageName = GetName(
@@ -309,12 +310,11 @@ class PackageInstantiation(VHDLModel_PackageInstantiation, DOMMixin):
         )
         uninstantiatedPackageSymbol = PackageReferenceSymbol(uninstantiatedPackageNode, uninstantiatedPackageName)
 
-        # FIXME: read use clauses (does it apply here too?)
         # FIXME: read generics
         # FIXME: read generic map
         # genericAssociations = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(instantiationNode))
 
-        return cls(packageNode, name, uninstantiatedPackageSymbol, documentation)
+        return cls(packageNode, name, uninstantiatedPackageSymbol, contextItems, documentation)
 
 
 @export

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -266,7 +266,7 @@ class Document(VHDLModel_Document):
                 self._AddPackageBody(packageBody)
 
             elif nodeKind == nodes.Iir_Kind.Package_Instantiation_Declaration:
-                package = PackageInstantiation.parse(libraryUnit)
+                package = PackageInstantiation.parse(libraryUnit, contextItems)
                 self._AddPackage(package)
 
             elif nodeKind == nodes.Iir_Kind.Context_Declaration:

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -109,9 +109,9 @@ class Design(VHDLModel_Design):
 
         if vhdlVersion not in self._SUPPORTED_VHDL_VERSIONS:
             supported = ", ".join(str(v) for v in self._SUPPORTED_VHDL_VERSIONS)
-            raise DOMException(
-                f"VHDL version '{vhdlVersion}' is not supported by pyGHDL.dom. Supported versions: {supported}."
-            )
+            ex = DOMException(f"VHDL version '{vhdlVersion}' is not supported by pyGHDL.dom.")
+            ex.add_note(f"Supported versions: {supported}.")
+            raise ex
 
         self._vhdlVersion = vhdlVersion
 

--- a/pyGHDL/dom/NonStandard.py
+++ b/pyGHDL/dom/NonStandard.py
@@ -89,12 +89,31 @@ from pyGHDL.dom.PSL import VerificationUnit, VerificationProperty, VerificationM
 class Design(VHDLModel_Design):
     _loadDefaultLibraryTime: Nullable[float]
     _analyzeTime: Nullable[float]
+    _vhdlVersion: VHDLVersion
 
     _warnings: List
 
+    #: VHDL versions currently supported by this class. Older revisions (87, 93, 2000, 2002) are
+    #: not planned to be supported for now.
+    _SUPPORTED_VHDL_VERSIONS = (VHDLVersion.VHDL2008, VHDLVersion.VHDL2019)
+
+    #: Mapping from a supported VHDLVersion to GHDL's '--std=' option value.
+    _VHDL_VERSION_TO_STD_OPTION = {
+        VHDLVersion.VHDL2008: "08",
+        VHDLVersion.VHDL2019: "19",
+    }
+
     @InheritDocString(VHDLModel_Design)
-    def __init__(self, name: str = None) -> None:
+    def __init__(self, name: str = None, vhdlVersion: VHDLVersion = VHDLVersion.VHDL2008) -> None:
         super().__init__(name)
+
+        if vhdlVersion not in self._SUPPORTED_VHDL_VERSIONS:
+            supported = ", ".join(str(v) for v in self._SUPPORTED_VHDL_VERSIONS)
+            raise DOMException(
+                f"VHDL version '{vhdlVersion}' is not supported by pyGHDL.dom. Supported versions: {supported}."
+            )
+
+        self._vhdlVersion = vhdlVersion
 
         self._loadDefaultLibraryTime = None
         self._analyzeTime = None
@@ -102,6 +121,10 @@ class Design(VHDLModel_Design):
         self._warnings = []
 
         self.__ghdl_init()
+
+    @readonly
+    def VHDLVersion(self) -> VHDLVersion:
+        return self._vhdlVersion
 
     def __ghdl_init(self):
         """Initialization: set options and then load libraries."""
@@ -112,7 +135,8 @@ class Design(VHDLModel_Design):
         # Collect error messages in memory
         errorout_memory.Install_Handler()
 
-        libghdl_set_option("--std=08")
+        stdOption = self._VHDL_VERSION_TO_STD_OPTION[self._vhdlVersion]
+        libghdl_set_option(f"--std={stdOption}")
 
         Flag_Gather_Comments.value = True
         Flag_Parse_Parenthesis.value = True

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -387,6 +387,7 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
             GetSequentialStatementsFromChainedNodes,
             GetRangeFromNode,
             GetName,
+            GetExpressionFromNode,
         )
 
         # spec = nodes.Get_Parameter_Specification(loopNode)
@@ -407,7 +408,8 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         #         f"Unknown discrete range kind '{rangeKind.name}' in for...loop statement at line {pos.Line}."
         #     )
 
-        condition = None
+        conditionNode = nodes.Get_Condition(loopNode)
+        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
 
         statementChain = nodes.Get_Sequential_Statement_Chain(loopNode)
         statements = GetSequentialStatementsFromChainedNodes(statementChain, "while", label)
@@ -531,11 +533,20 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
     def __init__(
         self,
         exitNode: Iir,
+        condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
-        super().__init__(condition=None, loopLabel=label)
+        super().__init__(condition=condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
-        # TODO: parse condition
+
+    @classmethod
+    def parse(cls, exitNode: Iir, label: str) -> "NextStatement":
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        conditionNode = nodes.Get_Condition(exitNode)
+        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+
+        return cls(exitNode, condition, label)
 
 
 @export
@@ -543,11 +554,20 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
     def __init__(
         self,
         exitNode: Iir,
+        condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
-        super().__init__(condition=None, loopLabel=label)
+        super().__init__(condition=condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
-        # TODO: parse condition
+
+    @classmethod
+    def parse(cls, exitNode: Iir, label: str) -> "ExitStatement":
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        conditionNode = nodes.Get_Condition(exitNode)
+        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+
+        return cls(exitNode, condition, label)
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -558,7 +558,7 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
         condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
-        super().__init__(condition=condition, loopLabel=label)
+        super().__init__(condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
 
     @classmethod
@@ -579,7 +579,7 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
         condition: ExpressionUnion = None,
         label: str = None,
     ) -> None:
-        super().__init__(condition=condition, loopLabel=label)
+        super().__init__(condition, loopLabel=label)
         DOMMixin.__init__(self, exitNode)
 
     @classmethod

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -447,10 +447,10 @@ class SequentialProcedureCall(VHDLModel_SequentialProcedureCall, DOMMixin):
         self,
         callNode: Iir,
         procedureName: Symbol,
-        parameterMappings: Iterable[ParameterAssociationItem],
+        parameterAssociationItems: Iterable[ParameterAssociationItem],
         label: str = None,
     ) -> None:
-        super().__init__(procedureName, parameterMappings, label)
+        super().__init__(procedureName, parameterAssociationItems, label)
         DOMMixin.__init__(self, callNode)
 
     @classmethod

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -49,6 +49,7 @@ from pyVHDLModel.Sequential import CaseStatement as VHDLModel_CaseStatement
 from pyVHDLModel.Sequential import ForLoopStatement as VHDLModel_ForLoopStatement
 from pyVHDLModel.Sequential import WhileLoopStatement as VHDLModel_WhileLoopStatement
 from pyVHDLModel.Sequential import NullStatement as VHDLModel_NullStatement
+from pyVHDLModel.Sequential import ReturnStatement as VHDLModel_ReturnStatement
 from pyVHDLModel.Sequential import WaitStatement as VHDLModel_WaitStatement
 from pyVHDLModel.Sequential import NextStatement as VHDLModel_NextStatement
 from pyVHDLModel.Sequential import ExitStatement as VHDLModel_ExitStatement
@@ -515,6 +516,27 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
         severity = None if severityNode is nodes.Null_Iir else GetExpressionFromNode(severityNode)
 
         return cls(reportNode, message, severity, label)
+
+
+@export
+class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
+    def __init__(
+        self,
+        returnNode: Iir,
+        returnValue: ExpressionUnion = None,
+        label: str = None,
+    ) -> None:
+        super().__init__(returnValue, label)
+        DOMMixin.__init__(self, returnNode)
+
+    @classmethod
+    def parse(cls, returnNode: Iir, label: str) -> "ReturnStatement":
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        returnValueNode = nodes.Get_Expression(returnNode)
+        returnValue = None if returnValueNode is nodes.Null_Iir else GetExpressionFromNode(returnValueNode)
+
+        return cls(returnNode, returnValue, label)
 
 
 @export

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -52,17 +52,13 @@ class Function(VHDLModel_Function, DOMMixin):
         node: Iir,
         functionName: str,
         returnType: Symbol,
+        isPure: bool = True,
         genericItems: List[GenericInterfaceItemMixin] = None,
         parameterItems: List[ParameterInterfaceItemMixin] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(functionName, documentation)
+        super().__init__(functionName, returnType, isPure, genericItems, parameterItems, documentation=documentation)
         DOMMixin.__init__(self, node)
-
-        # TODO: move to model
-        self._genericItems = [] if genericItems is None else [g for g in genericItems]
-        self._parameterItems = [] if parameterItems is None else [p for p in parameterItems]
-        self._returnType = returnType
 
     @classmethod
     def parse(cls, functionNode: Iir) -> "Function":
@@ -74,6 +70,7 @@ class Function(VHDLModel_Function, DOMMixin):
 
         functionName = GetNameOfNode(functionNode)
         documentation = GetDocumentationOfNode(functionNode)
+        isPure = nodes.Get_Pure_Flag(functionNode)
 
         generics = GetGenericsFromChainedNodes(nodes.Get_Generic_Chain(functionNode))
         parameters = GetParameterFromChainedNodes(nodes.Get_Interface_Declaration_Chain(functionNode))
@@ -82,7 +79,7 @@ class Function(VHDLModel_Function, DOMMixin):
         returnTypeName = GetName(returnType)
         returnTypeSymbol = SimpleSubtypeSymbol(returnType, returnTypeName)
 
-        return cls(functionNode, functionName, returnTypeSymbol, generics, parameters, documentation)
+        return cls(functionNode, functionName, returnTypeSymbol, isPure, generics, parameters, documentation)
 
 
 @export
@@ -95,12 +92,8 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         parameterItems: List[ParameterInterfaceItemMixin] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(procedureName, documentation)
+        super().__init__(procedureName, genericItems, parameterItems, documentation=documentation)
         DOMMixin.__init__(self, node)
-
-        # TODO: move to model
-        self._genericItems = [] if genericItems is None else [g for g in genericItems]
-        self._parameterItems = [] if parameterItems is None else [p for p in parameterItems]
 
     @classmethod
     def parse(cls, procedureNode: Iir) -> "Procedure":

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -55,9 +55,20 @@ class Function(VHDLModel_Function, DOMMixin):
         isPure: bool = True,
         genericItems: List[GenericInterfaceItemMixin] = None,
         parameterItems: List[ParameterInterfaceItemMixin] = None,
+        declaredItems: List = None,
+        statements: List["SequentialStatement"] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(functionName, returnType, isPure, genericItems, parameterItems, documentation=documentation)
+        super().__init__(
+            functionName,
+            returnType,
+            isPure,
+            genericItems,
+            parameterItems,
+            declaredItems,
+            statements,
+            documentation=documentation,
+        )
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -66,6 +77,8 @@ class Function(VHDLModel_Function, DOMMixin):
             GetName,
             GetGenericsFromChainedNodes,
             GetParameterFromChainedNodes,
+            GetDeclaredItemsFromChainedNodes,
+            GetSequentialStatementsFromChainedNodes,
         )
 
         functionName = GetNameOfNode(functionNode)
@@ -79,7 +92,28 @@ class Function(VHDLModel_Function, DOMMixin):
         returnTypeName = GetName(returnType)
         returnTypeSymbol = SimpleSubtypeSymbol(returnType, returnTypeName)
 
-        return cls(functionNode, functionName, returnTypeSymbol, isPure, generics, parameters, documentation)
+        declaredItems = []
+        statements = []
+        bodyNode = nodes.Get_Subprogram_Body(functionNode)
+        if bodyNode != nodes.Null_Iir:
+            declaredItems = GetDeclaredItemsFromChainedNodes(
+                nodes.Get_Declaration_Chain(bodyNode), "function", functionName
+            )
+            statements = GetSequentialStatementsFromChainedNodes(
+                nodes.Get_Sequential_Statement_Chain(bodyNode), "function", functionName
+            )
+
+        return cls(
+            functionNode,
+            functionName,
+            returnTypeSymbol,
+            isPure,
+            generics,
+            parameters,
+            declaredItems,
+            statements,
+            documentation,
+        )
 
 
 @export
@@ -90,9 +124,18 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         procedureName: str,
         genericItems: List[GenericInterfaceItemMixin] = None,
         parameterItems: List[ParameterInterfaceItemMixin] = None,
+        declaredItems: List = None,
+        statements: List["SequentialStatement"] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(procedureName, genericItems, parameterItems, documentation=documentation)
+        super().__init__(
+            procedureName,
+            genericItems,
+            parameterItems,
+            declaredItems,
+            statements,
+            documentation=documentation,
+        )
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -100,6 +143,8 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         from pyGHDL.dom._Translate import (
             GetGenericsFromChainedNodes,
             GetParameterFromChainedNodes,
+            GetDeclaredItemsFromChainedNodes,
+            GetSequentialStatementsFromChainedNodes,
         )
 
         procedureName = GetNameOfNode(procedureNode)
@@ -108,4 +153,15 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
         generics = GetGenericsFromChainedNodes(nodes.Get_Generic_Chain(procedureNode))
         parameters = GetParameterFromChainedNodes(nodes.Get_Interface_Declaration_Chain(procedureNode))
 
-        return cls(procedureNode, procedureName, generics, parameters, documentation)
+        declaredItems = []
+        statements = []
+        bodyNode = nodes.Get_Subprogram_Body(procedureNode)
+        if bodyNode != nodes.Null_Iir:
+            declaredItems = GetDeclaredItemsFromChainedNodes(
+                nodes.Get_Declaration_Chain(bodyNode), "procedure", procedureName
+            )
+            statements = GetSequentialStatementsFromChainedNodes(
+                nodes.Get_Sequential_Statement_Chain(bodyNode), "procedure", procedureName
+            )
+
+        return cls(procedureNode, procedureName, generics, parameters, declaredItems, statements, documentation)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -1015,9 +1015,9 @@ def GetSequentialStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Null_Statement:
             yield NullStatement(statement, label)
         elif kind == nodes.Iir_Kind.Next_Statement:
-            yield NextStatement(statement, label)
+            yield NextStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Exit_Statement:
-            yield ExitStatement(statement, label)
+            yield ExitStatement.parse(statement, label)
         else:
             raise DOMException(
                 f"Unknown sequential statement of kind '{kind.name}' in {entity} '{name}' at {position}."

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -728,7 +728,7 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
 
             actual = GetExpressionFromNode(nodes.Get_Actual(item))
 
-            yield cls(item, actual, formal)
+            yield cls(item, formal, actual)
         elif kind is nodes.Iir_Kind.Association_Element_Open:
             formalNode = nodes.Get_Formal(item)
             if formalNode is nodes.Null_Iir:
@@ -736,7 +736,7 @@ def GetMapAspect(mapAspect: Iir, cls: Type, entity: str) -> Generator[Associatio
             else:
                 formal = GetName(formalNode)
 
-            yield cls(item, OpenName(item), formal)
+            yield cls(item, formal, OpenName(item))
         else:
             pos = Position.parse(item)
             raise DOMException(f"Unknown association kind '{kind.name}' in {entity} map at line {pos.Line}.")

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -63,6 +63,7 @@ from pyGHDL.dom.Sequential import (
     NullStatement,
     NextStatement,
     ExitStatement,
+    ReturnStatement,
     SequentialProcedureCall,
 )
 
@@ -1018,6 +1019,8 @@ def GetSequentialStatementsFromChainedNodes(
             yield NextStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Exit_Statement:
             yield ExitStatement.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Return_Statement:
+            yield ReturnStatement.parse(statement, label)
         else:
             raise DOMException(
                 f"Unknown sequential statement of kind '{kind.name}' in {entity} '{name}' at {position}."

--- a/testsuite/pyunit/dom/Instantiation.py
+++ b/testsuite/pyunit/dom/Instantiation.py
@@ -51,7 +51,7 @@ class PackageInstantiation(TestCase):
       computed by ``Document.translate()`` and then silently discarded instead of being forwarded to
       ``PackageInstantiation.parse()``), and
     * that the ``generic map (...)`` aspect written at the instantiation site is translated into
-      ``GenericAssociations``.
+      ``GenericAssociationItems``.
 
     Note: the generic *declarations* of the referenced (uninstantiated) package cannot be read from the
     instantiation at this stage - ``Get_Uninstantiated_Package_Decl``/``Get_Generic_Chain`` on the instantiation node
@@ -98,7 +98,7 @@ class PackageInstantiation(TestCase):
         self.assertIsInstance(useClause, UseClause)
         self.assertEqual(1, len(useClause.Symbols))
 
-    def test_GenericAssociations(self):
+    def test_GenericAssociationItems(self):
         print()
 
         design = Design()
@@ -110,9 +110,9 @@ class PackageInstantiation(TestCase):
 
         packageInstantiation = document.Packages["instantiatedpackage"]
 
-        self.assertEqual(1, len(packageInstantiation.GenericAssociations))
+        self.assertEqual(1, len(packageInstantiation.GenericAssociationItems))
 
-        association = packageInstantiation.GenericAssociations[0]
+        association = packageInstantiation.GenericAssociationItems[0]
         self.assertEqual("WIDTH", association.Formal.Identifier)
         self.assertEqual(16, association.Actual.Value)
 

--- a/testsuite/pyunit/dom/Instantiation.py
+++ b/testsuite/pyunit/dom/Instantiation.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     exit(1)
 
 
-class Instantiation(TestCase):
+class PackageInstantiation(TestCase):
     """
     Checks translation of ``Iir_Kind.Package_Instantiation_Declaration``, in particular:
 

--- a/testsuite/pyunit/dom/PackageInstantiation.py
+++ b/testsuite/pyunit/dom/PackageInstantiation.py
@@ -1,0 +1,132 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of a package instantiation.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.DesignUnit import LibraryClause, UseClause
+
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Instantiation(TestCase):
+    """
+    Checks translation of ``Iir_Kind.Package_Instantiation_Declaration``, in particular:
+
+    * that ``library``/``use`` clauses preceding the instantiation are handed over as ``ContextItems`` (previously
+      computed by ``Document.translate()`` and then silently discarded instead of being forwarded to
+      ``PackageInstantiation.parse()``), and
+    * that the ``generic map (...)`` aspect written at the instantiation site is translated into
+      ``GenericAssociations``.
+
+    Note: the generic *declarations* of the referenced (uninstantiated) package cannot be read from the
+    instantiation at this stage - ``Get_Uninstantiated_Package_Decl``/``Get_Generic_Chain`` on the instantiation node
+    are only populated after semantic analysis resolves and macro-expands the reference, which
+    ``Document.translate()`` (parse-only) does not perform.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/PackageInstantiation.vhdl"
+
+    def test_Document(self):
+        print()
+
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+        print(f"{document.Path}:")
+        for warning in document._warnings:
+            print(f"  {warning}")
+
+        self.assertEqual(2, len(document.Packages))
+
+    def test_ContextItems(self):
+        print()
+
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+        print(f"{document.Path}:")
+        for warning in document._warnings:
+            print(f"  {warning}")
+
+        packageInstantiation = document.Packages["instantiatedpackage"]
+
+        self.assertEqual("InstantiatedPackage", packageInstantiation.Identifier)
+        self.assertEqual(2, len(packageInstantiation.ContextItems))
+
+        libraryClause, useClause = packageInstantiation.ContextItems
+
+        self.assertIsInstance(libraryClause, LibraryClause)
+        self.assertEqual(1, len(libraryClause.Symbols))
+        self.assertEqual("ieee", libraryClause.Symbols[0].Name.Identifier)
+
+        self.assertIsInstance(useClause, UseClause)
+        self.assertEqual(1, len(useClause.Symbols))
+
+    def test_GenericAssociations(self):
+        print()
+
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+        print(f"{document.Path}:")
+        for warning in document._warnings:
+            print(f"  {warning}")
+
+        packageInstantiation = document.Packages["instantiatedpackage"]
+
+        self.assertEqual(1, len(packageInstantiation.GenericAssociations))
+
+        association = packageInstantiation.GenericAssociations[0]
+        self.assertEqual("WIDTH", association.Formal.Identifier)
+        self.assertEqual(16, association.Actual.Value)
+
+    def test_PackageWithoutContextItemsOrGenericMap(self):
+        print()
+
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+        print(f"{document.Path}:")
+        for warning in document._warnings:
+            print(f"  {warning}")
+
+        package = document.Packages["genericpackage"]
+
+        self.assertEqual("GenericPackage", package.Identifier)
+        self.assertEqual(0, len(package.ContextItems))

--- a/testsuite/pyunit/dom/Sequential.py
+++ b/testsuite/pyunit/dom/Sequential.py
@@ -1,0 +1,83 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of sequential statements.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Sequential import WhileLoopStatement, ExitStatement, NextStatement
+
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class LoopConditions(TestCase):
+    """
+    Regression tests: WhileLoopStatement, ExitStatement, and NextStatement previously hardcoded
+    Condition to None instead of reading it - a while loop's own condition, and the 'when ...'
+    clause on exit/next statements, were silently dropped.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/LoopConditions.vhdl"
+
+    def test_WhileLoopCondition(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["loopconditions"]["rtl"]
+        process = architecture.Statements[0]
+        loop = process.Statements[0]
+
+        self.assertIsInstance(loop, WhileLoopStatement)
+        self.assertIsNotNone(loop.Condition)
+
+    def test_ExitAndNextConditions(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["loopconditions"]["rtl"]
+        process = architecture.Statements[0]
+        loop = process.Statements[0]
+
+        exitStatement, nextStatement = loop.Statements
+
+        self.assertIsInstance(exitStatement, ExitStatement)
+        self.assertIsNotNone(exitStatement.Condition)
+
+        self.assertIsInstance(nextStatement, NextStatement)
+        self.assertIsNotNone(nextStatement.Condition)

--- a/testsuite/pyunit/dom/Subprogram.py
+++ b/testsuite/pyunit/dom/Subprogram.py
@@ -1,0 +1,95 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of subprogram declarations.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Subprogram import Function, Procedure
+
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Subprograms(TestCase):
+    """
+    Regression tests: Function.ReturnType previously crashed with AttributeError on every instance
+    (pyVHDLModel's Function.__init__ never set self._returnType, and Subprogram.__init__ didn't
+    accept genericItems/parameterItems at all - pyGHDL.dom had to reach into private fields
+    directly to work around it). Also, Function's IsPure was never read from the source at all
+    (always defaulted to True, even for 'impure function').
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/Subprograms.vhdl"
+
+    def test_PureFunction(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        function = architecture.DeclaredItems[0]
+
+        self.assertIsInstance(function, Function)
+        self.assertEqual("double", function.Identifier)
+        self.assertIsNotNone(function.ReturnType)
+        self.assertTrue(function.IsPure)
+        self.assertEqual(1, len(function.ParameterItems))
+
+    def test_ImpureFunction(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        function = architecture.DeclaredItems[1]
+
+        self.assertIsInstance(function, Function)
+        self.assertEqual("get_random", function.Identifier)
+        self.assertIsNotNone(function.ReturnType)
+        self.assertFalse(function.IsPure)
+
+    def test_Procedure(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        procedure = architecture.DeclaredItems[2]
+
+        self.assertIsInstance(procedure, Procedure)
+        self.assertEqual("log", procedure.Identifier)
+        self.assertEqual(2, len(procedure.ParameterItems))

--- a/testsuite/pyunit/dom/Subprogram.py
+++ b/testsuite/pyunit/dom/Subprogram.py
@@ -88,8 +88,64 @@ class Subprograms(TestCase):
         design.Documents.append(document)
 
         architecture = document.Architectures["subprograms"]["rtl"]
-        procedure = architecture.DeclaredItems[2]
+        procedure = architecture.DeclaredItems[3]
 
         self.assertIsInstance(procedure, Procedure)
         self.assertEqual("log", procedure.Identifier)
         self.assertEqual(2, len(procedure.ParameterItems))
+
+
+class SubprogramBodies(TestCase):
+    """
+    Regression tests: Function/Procedure bodies (local declarations and sequential statements) were
+    previously never translated at all - Function.parse()/Procedure.parse() only ever read the
+    specification (name, generics, parameters, return type), never the paired
+    Function_Body/Procedure_Body node. Every Function/Procedure object always had empty
+    DeclaredItems/Statements regardless of what the body actually contained.
+
+    Also covers ReturnStatement, which previously crashed on .ReturnValue access
+    (pyVHDLModel's ReturnStatement misused ConditionalMixin, which sets self._condition, not
+    self._returnValue) and had no way to carry a label at all.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/Subprograms.vhdl"
+
+    def test_SimpleReturnStatement(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        function = architecture.DeclaredItems[0]
+
+        self.assertEqual(1, len(function.Statements))
+        returnStatement = function.Statements[0]
+        self.assertIsNotNone(returnStatement.ReturnValue)
+
+    def test_DeclaredItemsAndReturnValue(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        function = architecture.DeclaredItems[2]
+
+        self.assertEqual("scale", function.Identifier)
+        self.assertEqual(2, len(function.DeclaredItems))
+        self.assertEqual(("FACTOR",), function.DeclaredItems[0].Identifiers)
+        self.assertEqual(("result",), function.DeclaredItems[1].Identifiers)
+
+        self.assertEqual(1, len(function.Statements))
+        self.assertIsNotNone(function.Statements[0].ReturnValue)
+
+    def test_EmptyProcedureBody(self):
+        design = Design()
+        document = Document(self._filename)
+        design.Documents.append(document)
+
+        architecture = document.Architectures["subprograms"]["rtl"]
+        procedure = architecture.DeclaredItems[3]
+
+        self.assertEqual(0, len(procedure.DeclaredItems))
+        self.assertEqual(0, len(procedure.Statements))

--- a/testsuite/pyunit/dom/VHDLVersion.py
+++ b/testsuite/pyunit/dom/VHDLVersion.py
@@ -1,0 +1,96 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check Design's selectable VHDL version ('--std=' option).
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyVHDLModel import VHDLVersion
+
+from pyGHDL.dom import DOMException
+from pyGHDL.dom.NonStandard import Design, Document
+
+
+if __name__ == "__main__":
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class VHDLVersionSelection(TestCase):
+    """
+    Design previously hardcoded '--std=08' unconditionally, with no way to select a different VHDL
+    version - VHDL-2019 syntax (e.g. mode views) could never be parsed through pyGHDL.dom, even
+    though GHDL's own parser/analyzer supports it. Design now accepts a vhdlVersion parameter,
+    restricted to VHDLVersion.VHDL2008/VHDL2019 for now (older revisions are not planned to be
+    supported).
+    """
+
+    _root = Path(__file__).resolve().parent
+
+    def test_DefaultIsVHDL2008(self):
+        design = Design()
+
+        self.assertEqual(VHDLVersion.VHDL2008, design.VHDLVersion)
+
+    def test_ExplicitVHDL2008(self):
+        design = Design(vhdlVersion=VHDLVersion.VHDL2008)
+
+        self.assertEqual(VHDLVersion.VHDL2008, design.VHDLVersion)
+
+    def test_ExplicitVHDL2019(self):
+        design = Design(vhdlVersion=VHDLVersion.VHDL2019)
+
+        self.assertEqual(VHDLVersion.VHDL2019, design.VHDLVersion)
+
+    def test_UnsupportedVersion_RaisesDOMException(self):
+        for version in (VHDLVersion.VHDL87, VHDLVersion.VHDL93, VHDLVersion.VHDL2000, VHDLVersion.VHDL2002):
+            with self.subTest(version=version):
+                with self.assertRaises(DOMException):
+                    Design(vhdlVersion=version)
+
+    def test_VHDL2019SyntaxIsRejectedUnderVHDL2008(self):
+        design = Design(vhdlVersion=VHDLVersion.VHDL2008)
+
+        with self.assertRaises(DOMException):
+            document = Document(self._root / "examples/ModeView.vhdl")
+            design.Documents.append(document)
+
+    def test_VHDL2019SyntaxIsAcceptedUnderVHDL2019(self):
+        design = Design(vhdlVersion=VHDLVersion.VHDL2019)
+
+        # Parsing itself must succeed under --std=19. Translating the resulting Mode_View_Declaration
+        # into the DOM is a separate, not-yet-implemented step and is expected to still raise
+        # DOMException("Unknown declared item kind 'Mode_View_Declaration' ...") - update/remove this
+        # test once mode views are actually translated.
+        with self.assertRaises(DOMException):
+            document = Document(self._root / "examples/ModeView.vhdl")
+            design.Documents.append(document)

--- a/testsuite/pyunit/dom/examples/LoopConditions.vhdl
+++ b/testsuite/pyunit/dom/examples/LoopConditions.vhdl
@@ -1,0 +1,19 @@
+-- Author: Patrick Lehmann
+--
+-- Loop statements with conditions on the loop itself and on exit/next statements.
+entity LoopConditions is
+end entity LoopConditions;
+
+architecture rtl of LoopConditions is
+begin
+	process is
+		variable i : integer := 0;
+	begin
+		while i < 10 loop
+			exit when i = 5;
+			next when i = 2;
+			i := i + 1;
+		end loop;
+		wait;
+	end process;
+end architecture rtl;

--- a/testsuite/pyunit/dom/examples/ModeView.vhdl
+++ b/testsuite/pyunit/dom/examples/ModeView.vhdl
@@ -1,0 +1,14 @@
+-- Author: Patrick Lehmann
+--
+-- A VHDL-2019 mode view. Only parseable under --std=19.
+package ModeViewPkg is
+	type RecordType is record
+		a : bit;
+		b : bit;
+	end record;
+
+	view MasterView of RecordType is
+		a : out;
+		b : in;
+	end view;
+end package ModeViewPkg;

--- a/testsuite/pyunit/dom/examples/PackageInstantiation.vhdl
+++ b/testsuite/pyunit/dom/examples/PackageInstantiation.vhdl
@@ -1,0 +1,18 @@
+-- Author: Patrick Lehmann
+--
+-- A generic package and its instantiation, preceded by library/use clauses.
+package GenericPackage is
+	generic (
+		WIDTH : natural := 8
+	);
+
+	constant MAX_VALUE : natural := 2**WIDTH - 1;
+end package GenericPackage;
+
+library ieee;
+use     ieee.std_logic_1164.all;
+
+package InstantiatedPackage is new work.GenericPackage
+	generic map (
+		WIDTH => 16
+	);

--- a/testsuite/pyunit/dom/examples/Subprograms.vhdl
+++ b/testsuite/pyunit/dom/examples/Subprograms.vhdl
@@ -1,0 +1,22 @@
+-- Author: Patrick Lehmann
+--
+-- Functions and a procedure, exercising ReturnType, IsPure, and parameter capture.
+entity Subprograms is
+end entity Subprograms;
+
+architecture rtl of Subprograms is
+	function double(x : integer) return integer is
+	begin
+		return x * 2;
+	end function;
+
+	impure function get_random return integer is
+	begin
+		return 4;
+	end function;
+
+	procedure log(msg : string; level : natural) is
+	begin
+	end procedure;
+begin
+end architecture rtl;

--- a/testsuite/pyunit/dom/examples/Subprograms.vhdl
+++ b/testsuite/pyunit/dom/examples/Subprograms.vhdl
@@ -1,6 +1,7 @@
 -- Author: Patrick Lehmann
 --
--- Functions and a procedure, exercising ReturnType, IsPure, and parameter capture.
+-- Functions and a procedure, exercising ReturnType, IsPure, parameter capture, and subprogram
+-- body translation (declared items and statements).
 entity Subprograms is
 end entity Subprograms;
 
@@ -13,6 +14,13 @@ architecture rtl of Subprograms is
 	impure function get_random return integer is
 	begin
 		return 4;
+	end function;
+
+	function scale(x : integer) return integer is
+		constant FACTOR : integer := 3;
+		variable result : integer;
+	begin
+		return x * FACTOR;
 	end function;
 
 	procedure log(msg : string; level : natural) is


### PR DESCRIPTION
## Update

Renamed genericAssociations/genericMapItems -> genericAssociationItems, portAssociations -> portAssociationItems, and parameterMappings -> parameterAssociationItems throughout (ComponentInstantiation, EntityInstantiation, ConfigurationInstantiation, procedure call statements), matching the same rename in the companion PR https://github.com/VHDL/pyVHDLModel/pull/128 (open). This PR now depends on #128 for the underlying pyVHDLModel parameter/property names.

---

## Summary

`PackageInstantiation.parse()` (in `pyGHDL/dom/DesignUnit.py`) previously left two things unimplemented, tracked by two `FIXME` comments. Both are now addressed and verified against real GHDL analysis (built from the pre-built nightly wheel + `libgnat-13`, not just theory/unit tests).

### 1. `contextItems` (library/use clauses) - first commit

`Document.translate()` computed `contextItems` for every design unit but silently discarded them for `Package_Instantiation_Declaration` instead of forwarding them, unlike every other design unit kind (Entity, Architecture, Package, PackageBody, Configuration). Fixed by threading `contextItems` through `PackageInstantiation.__init__`/`.parse()`.

### 2. `genericItems` / generic map - second commit

Investigated what is actually available on a `Package_Instantiation_Declaration` node at parse time (i.e. without running semantic analysis, which `Document.translate()` does not do - it only calls `sem_lib.Load_File`):

- `Get_Generic_Chain` (the generic *declarations*) and `Get_Uninstantiated_Package_Decl` are both `Null_Iir` until semantic analysis resolves and macro-expands the referenced package. **Not obtainable at this stage** - confirmed empirically, not just from reading the IIR docs.
- `Get_Generic_Map_Aspect_Chain` (the actual `generic map (WIDTH => 16)` association written at the instantiation site) **is** populated right after parsing.

So this reads the generic map aspect via the already-existing `GetGenericMapAspect` helper (same one used for entity/component instantiations) and forwards it as `GenericAssociationItems`. Reading the referenced package's generic *declarations* would require adding a semantic-analysis step to the `Document`/`Design` pipeline - flagged as a real limitation, not silently worked around.

## Testing

Added `testsuite/pyunit/dom/Instantiation.py` (class `PackageInstantiation`) + a VHDL fixture (`examples/PackageInstantiation.vhdl`) with a generic package and its instantiation preceded by `library`/`use` clauses. All 4 tests pass; ran alongside the full existing `testsuite/pyunit/dom` suite (18 passed, 5 skipped - those need fixture directories not present in this sparse checkout) with no interference.

## Dependencies

- Requires https://github.com/VHDL/pyVHDLModel/pull/126 (contextItems) - **merged**.
- Requires https://github.com/VHDL/pyVHDLModel/pull/127 (genericAssociations, later renamed) - **merged**.
- Requires https://github.com/VHDL/pyVHDLModel/pull/128 (naming consistency: *AssociationItems) - open.
