### PR TITLE
Translate VHDL-2019 mode views

### DIFF
--- a/pyGHDL/dom/InterfaceItem.py
+++ b/pyGHDL/dom/InterfaceItem.py
@@ -42,16 +42,24 @@ from pyVHDLModel.Interface import GenericProcedureInterfaceItem as VHDLModel_Gen
 from pyVHDLModel.Interface import GenericFunctionInterfaceItem as VHDLModel_GenericFunctionInterfaceItem
 from pyVHDLModel.Interface import GenericPackageInterfaceItem as VHDLModel_GenericPackageInterfaceItem
 from pyVHDLModel.Interface import PortSignalInterfaceItem as VHDLModel_PortSignalInterfaceItem
+from pyVHDLModel.Interface import PortSimpleSignalInterfaceItem as VHDLModel_PortSimpleSignalInterfaceItem
+from pyVHDLModel.Interface import PortViewSignalInterfaceItem as VHDLModel_PortViewSignalInterfaceItem
 from pyVHDLModel.Interface import ParameterConstantInterfaceItem as VHDLModel_ParameterConstantInterfaceItem
 from pyVHDLModel.Interface import ParameterVariableInterfaceItem as VHDLModel_ParameterVariableInterfaceItem
 from pyVHDLModel.Interface import ParameterSignalInterfaceItem as VHDLModel_ParameterSignalInterfaceItem
+from pyVHDLModel.Interface import ParameterSimpleSignalInterfaceItem as VHDLModel_ParameterSimpleSignalInterfaceItem
+from pyVHDLModel.Interface import ParameterViewSignalInterfaceItem as VHDLModel_ParameterViewSignalInterfaceItem
 from pyVHDLModel.Interface import ParameterFileInterfaceItem as VHDLModel_ParameterFileInterfaceItem
+from pyVHDLModel.Interface import ModeViewDeclaration as VHDLModel_ModeViewDeclaration
+from pyVHDLModel.Interface import SimpleModeViewElement as VHDLModel_SimpleModeViewElement
+from pyVHDLModel.Interface import CompositeModeViewElement as VHDLModel_CompositeModeViewElement
 
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin
 from pyGHDL.dom._Utils import GetNameOfNode, GetModeOfNode, GetDocumentationOfNode
-from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode, GetExpressionFromNode
+from pyGHDL.dom._Translate import GetSubtypeIndicationFromNode, GetExpressionFromNode, GetName
+from pyGHDL.dom.Symbol import ModeViewSymbol
 
 
 @export
@@ -140,7 +148,7 @@ class GenericFunctionInterfaceItem(VHDLModel_GenericFunctionInterfaceItem, DOMMi
 
 
 @export
-class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, DOMMixin):
+class PortSimpleSignalInterfaceItem(VHDLModel_PortSimpleSignalInterfaceItem, DOMMixin):
     def __init__(
         self,
         node: Iir,
@@ -154,7 +162,7 @@ class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, DOMMixin):
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortSignalInterfaceItem":
+    def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortSimpleSignalInterfaceItem":
         name = GetNameOfNode(portNode)
         documentation = GetDocumentationOfNode(portNode)
         identifiers = [name]
@@ -167,6 +175,47 @@ class PortSignalInterfaceItem(VHDLModel_PortSignalInterfaceItem, DOMMixin):
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
         return cls(portNode, identifiers, mode, subtypeIndication, value, documentation)
+
+
+@export
+class PortViewSignalInterfaceItem(VHDLModel_PortViewSignalInterfaceItem, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          port (p : view MyView);
+
+    .. note::
+
+       ``Get_Subtype_Indication`` on an ``Interface_View_Declaration`` node is only populated after semantic
+       analysis has resolved the referenced mode view; since translation here is parse-only, ``Subtype``
+       stays ``None`` - the type is only implied by the referenced mode view.
+    """
+
+    def __init__(
+        self,
+        node: Iir,
+        identifiers: List[str],
+        modeViewIndication: ModeViewSymbol,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(identifiers, modeViewIndication, documentation=documentation)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, portNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "PortViewSignalInterfaceItem":
+        name = GetNameOfNode(portNode)
+        documentation = GetDocumentationOfNode(portNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
+
+        modeViewIndicationNode = nodes.Get_Mode_View_Indication(portNode)
+        modeViewNameNode = nodes.Get_Name(modeViewIndicationNode)
+        modeViewIndication = ModeViewSymbol(modeViewNameNode, GetName(modeViewNameNode))
+
+        return cls(portNode, identifiers, modeViewIndication, documentation)
 
 
 @export
@@ -230,7 +279,7 @@ class ParameterVariableInterfaceItem(VHDLModel_ParameterVariableInterfaceItem, D
 
 
 @export
-class ParameterSignalInterfaceItem(VHDLModel_ParameterSignalInterfaceItem, DOMMixin):
+class ParameterSimpleSignalInterfaceItem(VHDLModel_ParameterSimpleSignalInterfaceItem, DOMMixin):
     def __init__(
         self,
         node: Iir,
@@ -244,7 +293,7 @@ class ParameterSignalInterfaceItem(VHDLModel_ParameterSignalInterfaceItem, DOMMi
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterSignalInterfaceItem":
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterSimpleSignalInterfaceItem":
         name = GetNameOfNode(parameterNode)
         documentation = GetDocumentationOfNode(parameterNode)
         identifiers = [name]
@@ -257,6 +306,45 @@ class ParameterSignalInterfaceItem(VHDLModel_ParameterSignalInterfaceItem, DOMMi
         value = GetExpressionFromNode(defaultValue) if defaultValue != nodes.Null_Iir else None
 
         return cls(parameterNode, identifiers, mode, subtypeIndication, value, documentation)
+
+
+@export
+class ParameterViewSignalInterfaceItem(VHDLModel_ParameterViewSignalInterfaceItem, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          procedure proc(signal s : view MyView);
+
+    .. note::
+
+       See :class:`PortViewSignalInterfaceItem` for why ``Subtype`` stays ``None`` here.
+    """
+
+    def __init__(
+        self,
+        node: Iir,
+        identifiers: List[str],
+        modeViewIndication: ModeViewSymbol,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(identifiers, modeViewIndication, documentation=documentation)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, parameterNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "ParameterViewSignalInterfaceItem":
+        name = GetNameOfNode(parameterNode)
+        documentation = GetDocumentationOfNode(parameterNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
+
+        modeViewIndicationNode = nodes.Get_Mode_View_Indication(parameterNode)
+        modeViewNameNode = nodes.Get_Name(modeViewIndicationNode)
+        modeViewIndication = ModeViewSymbol(modeViewNameNode, GetName(modeViewNameNode))
+
+        return cls(parameterNode, identifiers, modeViewIndication, documentation)
 
 
 @export
@@ -275,3 +363,95 @@ class ParameterFileInterfaceItem(VHDLModel_ParameterFileInterfaceItem, DOMMixin)
         subtypeIndication = GetSubtypeIndicationFromNode(parameterNode, "parameter", name)
 
         return cls(parameterNode, identifiers, subtypeIndication, documentation)
+
+
+@export
+class SimpleModeViewElement(VHDLModel_SimpleModeViewElement, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          view MyView of RecordType is
+            a, b : out;
+          end view;
+    """
+
+    def __init__(self, node: Iir, identifiers: List[str], mode: Mode) -> None:
+        super().__init__(identifiers, mode)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, elementNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "SimpleModeViewElement":
+        name = GetNameOfNode(elementNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
+        mode = GetModeOfNode(elementNode)
+
+        return cls(elementNode, identifiers, mode)
+
+
+@export
+class CompositeModeViewElement(VHDLModel_CompositeModeViewElement, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          view OuterView of OuterRecord is
+            b : view InnerView;
+          end view;
+    """
+
+    def __init__(self, node: Iir, identifiers: List[str], modeViewName: ModeViewSymbol) -> None:
+        super().__init__(identifiers, modeViewName)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, elementNode: Iir, furtherIdentifiers: Iterable[str] = None) -> "CompositeModeViewElement":
+        name = GetNameOfNode(elementNode)
+        identifiers = [name]
+        if furtherIdentifiers is not None:
+            identifiers.extend(furtherIdentifiers)
+
+        modeViewNameNode = nodes.Get_Mode_View_Name(elementNode)
+        modeViewName = ModeViewSymbol(modeViewNameNode, GetName(modeViewNameNode))
+
+        return cls(elementNode, identifiers, modeViewName)
+
+
+@export
+class ModeViewDeclaration(VHDLModel_ModeViewDeclaration, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          view MyView of RecordType is
+            a : out;
+            b : in;
+          end view;
+    """
+
+    def __init__(
+        self,
+        node: Iir,
+        identifier: str,
+        subtype: Symbol,
+        elements: List = None,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(identifier, subtype, elements, documentation)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, modeViewNode: Iir) -> "ModeViewDeclaration":
+        from pyGHDL.dom._Translate import GetModeViewElementsFromChainedNodes
+
+        name = GetNameOfNode(modeViewNode)
+        documentation = GetDocumentationOfNode(modeViewNode)
+        subtypeIndication = GetSubtypeIndicationFromNode(modeViewNode, "mode view", name)
+        elements = GetModeViewElementsFromChainedNodes(nodes.Get_Elements_Definition_Chain(modeViewNode))
+
+        return cls(modeViewNode, name, subtypeIndication, elements, documentation)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -42,6 +42,7 @@ from pyTooling.Decorators import export, InheritDocString
 from pyVHDLModel.Name import Name
 from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryReferenceSymbol
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
+from pyVHDLModel.Symbol import ModeViewSymbol as VHDLModel_ModeViewSymbol
 from pyVHDLModel.Symbol import PackageMemberReferenceSymbol as VHDLModel_PackageMemberReferenceSymbol
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
@@ -101,6 +102,27 @@ class PackageReferenceSymbol(VHDLModel_PackageReferenceSymbol, DOMMixin):
     """
 
     @InheritDocString(VHDLModel_PackageReferenceSymbol)
+    def __init__(self, identifierNode: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class ModeViewSymbol(VHDLModel_ModeViewSymbol, DOMMixin):
+    """
+    Represents a reference (name) to a mode view declaration.
+
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.ModeViewSymbol`.
+
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          port (p : view MyView);
+          --          ^^^^^^
+    """
+
+    @InheritDocString(VHDLModel_ModeViewSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -551,6 +551,56 @@ def GetExpressionFromNode(node: Iir) -> ExpressionUnion:
 
 
 @export
+def GetModeViewElementsFromChainedNodes(nodeChain: Iir) -> Generator["ModeViewElement", None, None]:
+    """
+    Translates a chain of mode view elements (IIR nodes) to a sequence of
+    :class:`pyVHDLModel.Interface.ModeViewElement`.
+
+    :param nodeChain: The IIR node representing the first mode view element in the chain.
+    :return:          A generator returning mode view elements.
+
+    .. note::
+
+       Unlike declarations/interface items (where the *last* node in a ``Has_Identifier_List`` group owns
+       the shared subtype/value and earlier ones are Null), mode view elements are the other way around:
+       the *first* node in the group (``Has_Identifier_List == True``) owns the real ``Mode``/
+       ``Mode_View_Name`` - subsequent nodes only contribute their identifier, ending with the node where
+       ``Has_Identifier_List`` becomes ``False``. Verified against real GHDL analysis for
+       ``x, y : out;``: ``x`` has ``Has_Identifier_List=True``, ``Mode=out``; ``y`` has
+       ``Has_Identifier_List=False``, ``Mode=<unset>``.
+    """
+    from pyGHDL.dom.InterfaceItem import SimpleModeViewElement, CompositeModeViewElement
+
+    furtherIdentifiers = []
+    element = nodeChain
+    while element != nodes.Null_Iir:
+        kind = GetIirKindOfNode(element)
+        if kind == nodes.Iir_Kind.Simple_Mode_View_Element:
+            parseMethod = SimpleModeViewElement.parse
+        elif kind in (nodes.Iir_Kind.Array_Mode_View_Element, nodes.Iir_Kind.Record_Mode_View_Element):
+            parseMethod = CompositeModeViewElement.parse
+        else:
+            position = Position.parse(element)
+            raise DOMException(f"Unknown mode view element kind '{kind.name}' at {position}.")
+
+        elementToParse = element
+        if nodes.Get_Has_Identifier_List(element):
+            nextNode = nodes.Get_Chain(element)
+            for nextElement in utils.chain_iter(nextNode):
+                furtherIdentifiers.append(GetNameOfNode(nextElement))
+                if not nodes.Get_Has_Identifier_List(nextElement):
+                    element = nodes.Get_Chain(nextElement)
+                    break
+            else:
+                element = nodes.Null_Iir
+        else:
+            element = nodes.Get_Chain(element)
+
+        yield parseMethod(elementToParse, furtherIdentifiers)
+        furtherIdentifiers.clear()
+
+
+@export
 def GetGenericsFromChainedNodes(nodeChain: Iir) -> Generator[GenericInterfaceItemMixin, None, None]:
     """
     Translates a chain of generics (IIR nodes) to a sequence of :class:`pyVHDLModel.Interface.GenericInterfaceItem`.
@@ -626,36 +676,41 @@ def GetPortsFromChainedNodes(nodeChain: Iir) -> Generator[PortInterfaceItemMixin
     while port != nodes.Null_Iir:
         kind = GetIirKindOfNode(port)
         if kind == nodes.Iir_Kind.Interface_Signal_Declaration:
-            from pyGHDL.dom.InterfaceItem import PortSignalInterfaceItem
+            from pyGHDL.dom.InterfaceItem import PortSimpleSignalInterfaceItem
 
-            portToParse = port
+            parseMethod = PortSimpleSignalInterfaceItem.parse
+            parseNode = port
+        elif kind == nodes.Iir_Kind.Interface_View_Declaration:
+            from pyGHDL.dom.InterfaceItem import PortViewSignalInterfaceItem
 
-            # Lookahead for ports with multiple identifiers at once
-            if nodes.Get_Has_Identifier_List(port):
-                nextNode = nodes.Get_Chain(port)
-                for nextPort in utils.chain_iter(nextNode):
-                    # Consecutive identifiers are found, if the subtype indication is Null
-                    if nodes.Get_Subtype_Indication(nextPort) == nodes.Null_Iir:
-                        furtherIdentifiers.append(GetNameOfNode(nextPort))
-                    else:
-                        port = nextPort
-                        break
-
-                    # The last consecutive identifiers has no Identifier_List flag
-                    if not nodes.Get_Has_Identifier_List(nextPort):
-                        port = nodes.Get_Chain(nextPort)
-                        break
-                else:
-                    port = nodes.Null_Iir
-            else:
-                port = nodes.Get_Chain(port)
-
-            yield PortSignalInterfaceItem.parse(portToParse, furtherIdentifiers)
-            furtherIdentifiers.clear()
-            continue
+            parseMethod = PortViewSignalInterfaceItem.parse
+            parseNode = port
         else:
             position = Position.parse(port)
             raise DOMException(f"Unknown port kind '{kind.name}' in port '{port}' at {position}.")
+
+        # Lookahead for ports with multiple identifiers at once
+        if nodes.Get_Has_Identifier_List(port):
+            nextNode = nodes.Get_Chain(port)
+            for nextPort in utils.chain_iter(nextNode):
+                # Consecutive identifiers are found, if the subtype indication is Null
+                if nodes.Get_Subtype_Indication(nextPort) == nodes.Null_Iir:
+                    furtherIdentifiers.append(GetNameOfNode(nextPort))
+                else:
+                    port = nextPort
+                    break
+
+                # The last consecutive identifiers has no Identifier_List flag
+                if not nodes.Get_Has_Identifier_List(nextPort):
+                    port = nodes.Get_Chain(nextPort)
+                    break
+            else:
+                port = nodes.Null_Iir
+        else:
+            port = nodes.Get_Chain(port)
+
+        yield parseMethod(parseNode, furtherIdentifiers)
+        furtherIdentifiers.clear()
 
 
 @export
@@ -681,9 +736,14 @@ def GetParameterFromChainedNodes(nodeChain: Iir) -> Generator[ParameterInterface
             parseMethod = ParameterVariableInterfaceItem.parse
             parseNode = parameter
         elif kind == nodes.Iir_Kind.Interface_Signal_Declaration:
-            from pyGHDL.dom.InterfaceItem import ParameterSignalInterfaceItem
+            from pyGHDL.dom.InterfaceItem import ParameterSimpleSignalInterfaceItem
 
-            parseMethod = ParameterSignalInterfaceItem.parse
+            parseMethod = ParameterSimpleSignalInterfaceItem.parse
+            parseNode = parameter
+        elif kind == nodes.Iir_Kind.Interface_View_Declaration:
+            from pyGHDL.dom.InterfaceItem import ParameterViewSignalInterfaceItem
+
+            parseMethod = ParameterViewSignalInterfaceItem.parse
             parseNode = parameter
         elif kind == nodes.Iir_Kind.Interface_File_Declaration:
             from pyGHDL.dom.InterfaceItem import ParameterFileInterfaceItem
@@ -794,6 +854,11 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
 
             elif kind == nodes.Iir_Kind.Subtype_Declaration:
                 yield GetSubtypeFromNode(item)
+
+            elif kind == nodes.Iir_Kind.Mode_View_Declaration:
+                from pyGHDL.dom.InterfaceItem import ModeViewDeclaration
+
+                yield ModeViewDeclaration.parse(item)
 
             elif kind == nodes.Iir_Kind.Function_Declaration:
                 if nodes.Get_Has_Body(item):

--- a/testsuite/pyunit/dom/ModeView.py
+++ b/testsuite/pyunit/dom/ModeView.py
@@ -1,0 +1,113 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of VHDL-2019 mode views.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyVHDLModel import VHDLVersion
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.InterfaceItem import (
+    ModeViewDeclaration,
+    SimpleModeViewElement,
+    CompositeModeViewElement,
+    PortViewSignalInterfaceItem,
+    ParameterViewSignalInterfaceItem,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class ModeViews(TestCase):
+    """
+    Checks translation of VHDL-2019 mode views: Mode_View_Declaration, Simple/Array/Record
+    Mode_View_Element (Array/Record merged into CompositeModeViewElement), Interface_View_Declaration
+    on ports and subprogram parameters, multi-identifier elements sharing one mode, nested/hierarchical
+    composite elements, and the 'converse attribute.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/ModeViews.vhdl"
+
+    @staticmethod
+    def _design() -> Design:
+        design = Design(vhdlVersion=VHDLVersion.VHDL2019)
+        document = Document(ModeViews._filename)
+        design.Documents.append(document)
+        return design
+
+    def test_SimpleAndCompositeElements(self) -> None:
+        design = self._design()
+        document = design.Documents[0]
+        outerView = document.Packages["modeviews"].DeclaredItems[3]
+
+        self.assertIsInstance(outerView, ModeViewDeclaration)
+        self.assertEqual("OuterView", outerView.Identifier)
+        self.assertEqual(2, len(outerView.Elements))
+
+        ab, c = outerView.Elements
+        self.assertIsInstance(ab, SimpleModeViewElement)
+        self.assertEqual(("a", "b"), ab.Identifiers)
+
+        self.assertIsInstance(c, CompositeModeViewElement)
+        self.assertEqual(("c",), c.Identifiers)
+        self.assertEqual("InnerView", c.ModeViewName.Name.Identifier)
+
+    def test_PortWithModeView(self) -> None:
+        design = self._design()
+        document = design.Documents[0]
+        entity = document.Entities["consumer"]
+
+        p1, p2 = entity.PortItems
+        self.assertIsInstance(p1, PortViewSignalInterfaceItem)
+        self.assertEqual(("p1",), p1.Identifiers)
+        self.assertEqual("OuterView", p1.ModeViewIndication.Name.Identifier)
+
+        self.assertIsInstance(p2, PortViewSignalInterfaceItem)
+        self.assertEqual(("p2",), p2.Identifiers)
+        # 'converse - the reference is an AttributeName, not a plain SimpleName
+        self.assertEqual("converse", p2.ModeViewIndication.Name.Identifier)
+
+    def test_ParameterWithModeView(self) -> None:
+        design = self._design()
+        document = design.Documents[0]
+        architecture = document.Architectures["consumer"]["rtl"]
+        procedure = architecture.DeclaredItems[0]
+
+        parameter = procedure.ParameterItems[0]
+        self.assertIsInstance(parameter, ParameterViewSignalInterfaceItem)
+        self.assertEqual(("s",), parameter.Identifiers)
+        self.assertEqual("OuterView", parameter.ModeViewIndication.Name.Identifier)

--- a/testsuite/pyunit/dom/VHDLVersion.py
+++ b/testsuite/pyunit/dom/VHDLVersion.py
@@ -87,10 +87,9 @@ class VHDLVersionSelection(TestCase):
     def test_VHDL2019SyntaxIsAcceptedUnderVHDL2019(self):
         design = Design(vhdlVersion=VHDLVersion.VHDL2019)
 
-        # Parsing itself must succeed under --std=19. Translating the resulting Mode_View_Declaration
-        # into the DOM is a separate, not-yet-implemented step and is expected to still raise
-        # DOMException("Unknown declared item kind 'Mode_View_Declaration' ...") - update/remove this
-        # test once mode views are actually translated.
-        with self.assertRaises(DOMException):
-            document = Document(self._root / "examples/ModeView.vhdl")
-            design.Documents.append(document)
+        document = Document(self._root / "examples/ModeView.vhdl")
+        design.Documents.append(document)
+
+        modeView = document.Packages["modeviewpkg"].DeclaredItems[1]
+        self.assertEqual("MasterView", modeView.Identifier)
+        self.assertEqual(2, len(modeView.Elements))

--- a/testsuite/pyunit/dom/examples/ModeViews.vhdl
+++ b/testsuite/pyunit/dom/examples/ModeViews.vhdl
@@ -1,0 +1,42 @@
+-- Author: Patrick Lehmann
+--
+-- VHDL-2019 mode views: simple/composite elements, multiple identifiers sharing one mode,
+-- 'converse, and view-typed ports/parameters.
+package ModeViews is
+	type InnerRecord is record
+		x : bit;
+		y : bit;
+	end record;
+
+	type OuterRecord is record
+		a : bit;
+		b : bit;
+		c : InnerRecord;
+	end record;
+
+	view InnerView of InnerRecord is
+		x : out;
+		y : in;
+	end view;
+
+	view OuterView of OuterRecord is
+		a, b : out;
+		c    : view InnerView;
+	end view;
+end package ModeViews;
+
+use work.ModeViews.all;
+
+entity Consumer is
+	port (
+		p1 : view OuterView;
+		p2 : view OuterView'converse
+	);
+end entity Consumer;
+
+architecture rtl of Consumer is
+	procedure proc(signal s : view OuterView) is
+	begin
+	end procedure;
+begin
+end architecture rtl;


### PR DESCRIPTION
## Summary

Implements translation for VHDL-2019 mode views, using the classes added in
VHDL/pyVHDLModel#134 (`ModeViewDeclaration`, `SimpleModeViewElement`, `CompositeModeViewElement`,
`ModeViewSymbol`, `PortViewSignalInterfaceItem`, `ParameterViewSignalInterfaceItem`).

### Changes

- `pyGHDL/dom/Symbol.py`: `ModeViewSymbol`, mirroring `PackageReferenceSymbol`.
- `pyGHDL/dom/InterfaceItem.py`: renamed `PortSignalInterfaceItem` -> `PortSimpleSignalInterfaceItem` and
  `ParameterSignalInterfaceItem` -> `ParameterSimpleSignalInterfaceItem` to match the pyVHDLModel split;
  added `PortViewSignalInterfaceItem`, `ParameterViewSignalInterfaceItem`, `ModeViewDeclaration`,
  `SimpleModeViewElement`, `CompositeModeViewElement`.
- `pyGHDL/dom/_Translate.py`:
  - `GetPortsFromChainedNodes`/`GetParameterFromChainedNodes` restructured to a shared
    `parseMethod`/`parseNode` dispatch (matching the pattern already used for parameters) and
    extended with `Interface_View_Declaration` handling.
  - New `GetModeViewElementsFromChainedNodes`.
  - `Mode_View_Declaration` wired into `GetDeclaredItemsFromChainedNodes`.

### A finding worth flagging explicitly

While implementing the multi-identifier case (`a, b : out;`), I verified against real GHDL that mode
view elements use the *opposite* ownership convention from every other construct in this file.
Everywhere else, the *last* node in a `Has_Identifier_List` group owns the shared value and earlier
ones are null. For mode view elements it's reversed: `a` (first, `Has_Identifier_List=True`) owns the
real `Mode`; `b` (last, `Has_Identifier_List=False`) does not. My first implementation assumed the usual
pattern and was wrong - caught it by testing directly rather than trusting the analogy, and documented
the inversion clearly in the function's docstring so it doesn't trip up whoever touches this code next.

### Also confirmed against real GHDL

- Nested/hierarchical composite elements (a record field itself assigned a named sub-view).
- The `'converse` attribute - resolves to an ordinary `AttributeName`, no special handling needed.
- View-typed ports and view-typed subprogram parameters.
- A view-typed **generic** still correctly fails with `Unknown generic kind` rather than silently
  accepting it - generics are restricted to constants/types/subprograms/packages per the LRM (confirmed
  with the model owner directly), even though GHDL's parser alone doesn't enforce that restriction.

## Testing

Updated `testsuite/pyunit/dom/VHDLVersion.py::test_VHDL2019SyntaxIsAcceptedUnderVHDL2019` - it was
written as a deliberate canary (comment: "update/remove this test once mode views are actually
translated") and now asserts successful translation instead of the previously-expected `DOMException`.

Added `testsuite/pyunit/dom/ModeView.py` + `examples/ModeViews.vhdl`. Full suite: `35 passed` (was 32),
5 skipped, no regressions.

## Dependency

Requires https://github.com/VHDL/pyVHDLModel/pull/134 (open, under your review).
