### PR TITLE
Subprogram instantiation (VHDL-2008 generic subprograms) and Alias

### DIFF
--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -39,8 +39,7 @@
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Declaration import Alias as VHDLModel_Alias
-from pyVHDLModel.Name import Name
-from pyVHDLModel.Symbol import Symbol
+from pyVHDLModel.Symbol import Symbol, PossibleReference
 
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
@@ -54,7 +53,7 @@ class Alias(VHDLModel_Alias, DOMMixin):
         self,
         node: Iir,
         aliasName: str,
-        name: Name,
+        name: Symbol,
         subtype: Symbol = None,
         documentation: str = None,
     ) -> None:
@@ -64,6 +63,7 @@ class Alias(VHDLModel_Alias, DOMMixin):
     @classmethod
     def parse(cls, aliasNode: Iir):
         from pyGHDL.dom._Translate import GetName, GetSubtypeIndicationFromNode
+        from pyGHDL.dom.Symbol import Symbol as DOMSymbol
 
         aliasName = GetNameOfNode(aliasNode)
         documentation = GetDocumentationOfNode(aliasNode)
@@ -73,15 +73,18 @@ class Alias(VHDLModel_Alias, DOMMixin):
             # FIXME: the parameter/return type marks of the signature (used to disambiguate between
             #        overloaded subprograms/operators, e.g. 'add[integer, integer return integer]')
             #        are not captured - only the aliased name itself (the signature's prefix).
-            name = GetName(nodes.Get_Signature_Prefix(nameNode))
-        else:
-            name = GetName(nameNode)
+            nameNode = nodes.Get_Signature_Prefix(nameNode)
 
         subtypeIndicationNode = nodes.Get_Subtype_Indication(aliasNode)
-        subtype = (
-            None
-            if subtypeIndicationNode == nodes.Null_Iir
-            else GetSubtypeIndicationFromNode(aliasNode, "alias", aliasName)
-        )
+        if subtypeIndicationNode == nodes.Null_Iir:
+            subtype = None
+            # Without a subtype indication, the alias can refer to almost anything nameable.
+            possibleReferences = PossibleReference.PackageMember | PossibleReference.EnumLiteral
+        else:
+            subtype = GetSubtypeIndicationFromNode(aliasNode, "alias", aliasName)
+            # With a subtype indication, the LRM restricts this to referencing an object.
+            possibleReferences = PossibleReference.Object
+
+        name = DOMSymbol(nameNode, GetName(nameNode), possibleReferences)
 
         return cls(aliasNode, aliasName, name, subtype, documentation)

--- a/pyGHDL/dom/Misc.py
+++ b/pyGHDL/dom/Misc.py
@@ -39,23 +39,49 @@
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Declaration import Alias as VHDLModel_Alias
+from pyVHDLModel.Name import Name
+from pyVHDLModel.Symbol import Symbol
 
 from pyGHDL.libghdl._types import Iir
+from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin
-from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
+from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetIirKindOfNode
 
 
 @export
 class Alias(VHDLModel_Alias, DOMMixin):
-    def __init__(self, node: Iir, aliasName: str, documentation: str = None) -> None:
-        super().__init__(aliasName, documentation)
+    def __init__(
+        self,
+        node: Iir,
+        aliasName: str,
+        name: Name,
+        subtype: Symbol = None,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(aliasName, name, subtype, documentation)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, aliasNode: Iir):
+        from pyGHDL.dom._Translate import GetName, GetSubtypeIndicationFromNode
+
         aliasName = GetNameOfNode(aliasNode)
         documentation = GetDocumentationOfNode(aliasNode)
 
-        # FIXME: add an implementation
+        nameNode = nodes.Get_Name(aliasNode)
+        if GetIirKindOfNode(nameNode) == nodes.Iir_Kind.Signature:
+            # FIXME: the parameter/return type marks of the signature (used to disambiguate between
+            #        overloaded subprograms/operators, e.g. 'add[integer, integer return integer]')
+            #        are not captured - only the aliased name itself (the signature's prefix).
+            name = GetName(nodes.Get_Signature_Prefix(nameNode))
+        else:
+            name = GetName(nameNode)
 
-        return cls(aliasNode, aliasName)
+        subtypeIndicationNode = nodes.Get_Subtype_Indication(aliasNode)
+        subtype = (
+            None
+            if subtypeIndicationNode == nodes.Null_Iir
+            else GetSubtypeIndicationFromNode(aliasNode, "alias", aliasName)
+        )
+
+        return cls(aliasNode, aliasName, name, subtype, documentation)

--- a/pyGHDL/dom/Subprogram.py
+++ b/pyGHDL/dom/Subprogram.py
@@ -37,11 +37,13 @@ from pyTooling.Decorators import export
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Interface import GenericInterfaceItemMixin, ParameterInterfaceItemMixin
 from pyVHDLModel.Subprogram import Procedure as VHDLModel_Procedure, Function as VHDLModel_Function
+from pyVHDLModel.Instantiation import FunctionInstantiation as VHDLModel_FunctionInstantiation
+from pyVHDLModel.Instantiation import ProcedureInstantiation as VHDLModel_ProcedureInstantiation
 
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin
-from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode
+from pyGHDL.dom._Utils import GetNameOfNode, GetDocumentationOfNode, GetIirKindOfNode
 from pyGHDL.dom.Symbol import SimpleSubtypeSymbol
 
 
@@ -165,3 +167,91 @@ class Procedure(VHDLModel_Procedure, DOMMixin):
             )
 
         return cls(procedureNode, procedureName, generics, parameters, declaredItems, statements, documentation)
+
+
+@export
+class FunctionInstantiation(VHDLModel_FunctionInstantiation, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          function add_int is new work.pkg.generic_add generic map (T => integer);
+
+    .. note::
+
+       Neither ``ReturnType`` nor ``IsPure`` can be read here: verified against real GHDL that
+       ``Get_Return_Type``/``Get_Pure_Flag`` on a ``Function_Instantiation_Declaration`` are not
+       resolved at the parse-only level this project operates at (``Get_Pure_Flag`` returns ``False``
+       even for an actually-pure referenced function) - both are properties of the referenced
+       uninstantiated function, not the instantiation itself, and can only be known by resolving it.
+    """
+
+    def __init__(
+        self,
+        node: Iir,
+        functionName: str,
+        subprogramReference: Symbol,
+        genericAssociationItems: List = None,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(functionName, subprogramReference, genericAssociationItems=genericAssociationItems, documentation=documentation)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, functionNode: Iir) -> "FunctionInstantiation":
+        from pyGHDL.dom._Translate import GetName, GetGenericMapAspect
+        from pyGHDL.dom.Symbol import SubprogramReferenceSymbol
+
+        functionName = GetNameOfNode(functionNode)
+        documentation = GetDocumentationOfNode(functionNode)
+
+        uninstantiatedNameNode = nodes.Get_Uninstantiated_Subprogram_Name(functionNode)
+        if GetIirKindOfNode(uninstantiatedNameNode) == nodes.Iir_Kind.Signature:
+            # FIXME: same limitation as Alias.parse() - the signature's parameter/return type marks
+            #        (used to disambiguate overloaded subprograms) are not captured.
+            uninstantiatedNameNode = nodes.Get_Signature_Prefix(uninstantiatedNameNode)
+        subprogramReference = SubprogramReferenceSymbol(uninstantiatedNameNode, GetName(uninstantiatedNameNode))
+
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(functionNode))
+
+        return cls(functionNode, functionName, subprogramReference, genericAssociationItems, documentation)
+
+
+@export
+class ProcedureInstantiation(VHDLModel_ProcedureInstantiation, DOMMixin):
+    """
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          procedure my_proc is new work.pkg.generic_proc generic map (T => integer);
+    """
+
+    def __init__(
+        self,
+        node: Iir,
+        procedureName: str,
+        subprogramReference: Symbol,
+        genericAssociationItems: List = None,
+        documentation: str = None,
+    ) -> None:
+        super().__init__(procedureName, subprogramReference, genericAssociationItems=genericAssociationItems, documentation=documentation)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, procedureNode: Iir) -> "ProcedureInstantiation":
+        from pyGHDL.dom._Translate import GetName, GetGenericMapAspect
+        from pyGHDL.dom.Symbol import SubprogramReferenceSymbol
+
+        procedureName = GetNameOfNode(procedureNode)
+        documentation = GetDocumentationOfNode(procedureNode)
+
+        uninstantiatedNameNode = nodes.Get_Uninstantiated_Subprogram_Name(procedureNode)
+        if GetIirKindOfNode(uninstantiatedNameNode) == nodes.Iir_Kind.Signature:
+            uninstantiatedNameNode = nodes.Get_Signature_Prefix(uninstantiatedNameNode)
+        subprogramReference = SubprogramReferenceSymbol(uninstantiatedNameNode, GetName(uninstantiatedNameNode))
+
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(procedureNode))
+
+        return cls(procedureNode, procedureName, subprogramReference, genericAssociationItems, documentation)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -40,6 +40,8 @@ from pyGHDL.dom.Name import SimpleName
 from pyTooling.Decorators import export, InheritDocString
 
 from pyVHDLModel.Name import Name
+from pyVHDLModel.Symbol import Symbol as VHDLModel_Symbol
+from pyVHDLModel.Symbol import PossibleReference
 from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryReferenceSymbol
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
 from pyVHDLModel.Symbol import ModeViewSymbol as VHDLModel_ModeViewSymbol
@@ -64,6 +66,22 @@ from pyVHDLModel.Symbol import IndexedObjectOrFunctionCallSymbol as VHDLModel_In
 from pyGHDL.libghdl._types import Iir
 from pyGHDL.dom import DOMMixin
 from pyGHDL.dom.Range import Range
+
+
+@export
+class Symbol(VHDLModel_Symbol, DOMMixin):
+    """
+    Generic reference (name) to a language entity where no single, fixed
+    :class:`~pyVHDLModel.Symbol.PossibleReference` value fits - e.g. an alias's target, which may or may not
+    be restricted to an object depending on whether a subtype indication is present.
+
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.Symbol`.
+    """
+
+    @InheritDocString(VHDLModel_Symbol)
+    def __init__(self, identifierNode: Iir, name: Name, possibleReferences: PossibleReference) -> None:
+        super().__init__(name, possibleReferences)
+        DOMMixin.__init__(self, identifierNode)
 
 
 @export

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -43,6 +43,7 @@ from pyVHDLModel.Name import Name
 from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryReferenceSymbol
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
 from pyVHDLModel.Symbol import ModeViewSymbol as VHDLModel_ModeViewSymbol
+from pyVHDLModel.Symbol import SubprogramReferenceSymbol as VHDLModel_SubprogramReferenceSymbol
 from pyVHDLModel.Symbol import PackageMemberReferenceSymbol as VHDLModel_PackageMemberReferenceSymbol
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
@@ -123,6 +124,28 @@ class ModeViewSymbol(VHDLModel_ModeViewSymbol, DOMMixin):
     """
 
     @InheritDocString(VHDLModel_ModeViewSymbol)
+    def __init__(self, identifierNode: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class SubprogramReferenceSymbol(VHDLModel_SubprogramReferenceSymbol, DOMMixin):
+    """
+    Represents a reference (name) to a subprogram (procedure or function).
+
+    This class implements a :mod:`pyGHDL.dom` object derived from
+    :class:`pyVHDLModel.Symbol.SubprogramReferenceSymbol`.
+
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          function f is new g generic map (...);
+          --                  ^
+    """
+
+    @InheritDocString(VHDLModel_SubprogramReferenceSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -177,7 +177,6 @@ from pyGHDL.dom.Concurrent import (
     ConcurrentAssertStatement,
 )
 from pyGHDL.dom.Subprogram import Function, Procedure
-from pyGHDL.dom.Misc import Alias
 from pyGHDL.dom.PSL import DefaultClock
 
 
@@ -897,7 +896,9 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
             elif kind == nodes.Iir_Kind.Protected_Type_Body:
                 yield ProtectedTypeBody.parse(item)
             elif kind == nodes.Iir_Kind.Object_Alias_Declaration:
-                yield GetAliasFromNode(item)
+                from pyGHDL.dom.Misc import Alias
+
+                yield Alias.parse(item)
             elif kind == nodes.Iir_Kind.Component_Declaration:
                 from pyGHDL.dom.DesignUnit import Component
 
@@ -1092,7 +1093,4 @@ def GetSequentialStatementsFromChainedNodes(
             )
 
 
-def GetAliasFromNode(aliasNode: Iir):
-    aliasName = GetNameOfNode(aliasNode)
 
-    return Alias(aliasNode, aliasName)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -868,6 +868,14 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                 lastKind = kind
                 item = nodes.Get_Chain(item)
                 continue
+            elif kind == nodes.Iir_Kind.Function_Instantiation_Declaration:
+                from pyGHDL.dom.Subprogram import FunctionInstantiation
+
+                yield FunctionInstantiation.parse(item)
+            elif kind == nodes.Iir_Kind.Procedure_Instantiation_Declaration:
+                from pyGHDL.dom.Subprogram import ProcedureInstantiation
+
+                yield ProcedureInstantiation.parse(item)
             elif kind == nodes.Iir_Kind.Function_Body:
                 if lastKind is nodes.Iir_Kind.Function_Declaration:
                     pass

--- a/testsuite/pyunit/dom/Alias.py
+++ b/testsuite/pyunit/dom/Alias.py
@@ -35,6 +35,7 @@ from unittest import TestCase
 
 from pyGHDL.dom.NonStandard import Design, Document
 from pyGHDL.dom.Misc import Alias
+from pyGHDL.dom.Symbol import Symbol
 
 
 if __name__ == "__main__":  # pragma: no cover
@@ -70,7 +71,7 @@ class Aliases(TestCase):
 
         self.assertIsInstance(alias, Alias)
         self.assertEqual("a", alias.Identifier)
-        self.assertIsNotNone(alias.Name)
+        self.assertIsInstance(alias.Name, Symbol)
         self.assertIsNotNone(alias.Subtype)
 
     def test_AliasWithoutSubtype(self) -> None:

--- a/testsuite/pyunit/dom/Alias.py
+++ b/testsuite/pyunit/dom/Alias.py
@@ -1,0 +1,102 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of alias declarations.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Misc import Alias
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Aliases(TestCase):
+    """
+    Regression tests: Alias.parse() previously did nothing except read the alias's own identifier -
+    the aliased name and optional subtype indication were never read at all.
+
+    Also confirms that every alias variant (object, type, operator-with-signature) arrives as a single
+    Object_Alias_Declaration kind at the parse-only level this project operates at - GHDL's parser
+    never produces Non_Object_Alias_Declaration; that split only happens during semantic analysis.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/Aliases.vhdl"
+
+    @staticmethod
+    def _package():
+        design = Design()
+        document = Document(Aliases._filename)
+        design.Documents.append(document)
+        return document.Packages["aliases"]
+
+    def test_AliasWithSubtype(self) -> None:
+        """``alias a : bit_vector(3 downto 0) is s(3 downto 0);``"""
+        pkg = self._package()
+        alias = pkg.DeclaredItems[1]
+
+        self.assertIsInstance(alias, Alias)
+        self.assertEqual("a", alias.Identifier)
+        self.assertIsNotNone(alias.Name)
+        self.assertIsNotNone(alias.Subtype)
+
+    def test_AliasWithoutSubtype(self) -> None:
+        """``alias b is s;``"""
+        pkg = self._package()
+        alias = pkg.DeclaredItems[2]
+
+        self.assertIsInstance(alias, Alias)
+        self.assertEqual("b", alias.Identifier)
+        self.assertIsNotNone(alias.Name)
+        self.assertIsNone(alias.Subtype)
+
+    def test_TypeAlias(self) -> None:
+        """``alias MyInt is Integer2;`` - arrives as Object_Alias_Declaration, same as any other alias."""
+        pkg = self._package()
+        alias = pkg.DeclaredItems[4]
+
+        self.assertIsInstance(alias, Alias)
+        self.assertEqual("MyInt", alias.Identifier)
+        self.assertIsNotNone(alias.Name)
+
+    def test_OperatorAliasWithSignature(self) -> None:
+        """``alias "+" is add[integer, integer return integer];`` - Name is extracted from the
+        Signature node's prefix; the parameter/return type marks are not captured (documented FIXME)."""
+        pkg = self._package()
+        alias = pkg.DeclaredItems[5]
+
+        self.assertIsInstance(alias, Alias)
+        self.assertIsNotNone(alias.Name)

--- a/testsuite/pyunit/dom/SubprogramInstantiation.py
+++ b/testsuite/pyunit/dom/SubprogramInstantiation.py
@@ -1,0 +1,83 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of subprogram instantiations.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Subprogram import FunctionInstantiation, ProcedureInstantiation
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class SubprogramInstantiations(TestCase):
+    """
+    Checks translation of VHDL-2008 subprogram instantiations (generic subprograms):
+    Function_Instantiation_Declaration and Procedure_Instantiation_Declaration.
+
+    FunctionInstantiation/ProcedureInstantiation were previously bare stub classes with no way to
+    populate SubprogramReference or GenericAssociationItems at all.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/SubprogramInstantiation.vhdl"
+
+    @staticmethod
+    def _package():
+        design = Design()
+        document = Document(SubprogramInstantiations._filename)
+        design.Documents.append(document)
+        return document.Packages["instances"]
+
+    def test_FunctionInstantiation(self) -> None:
+        pkg = self._package()
+        functionInstantiation = pkg.DeclaredItems[0]
+
+        self.assertIsInstance(functionInstantiation, FunctionInstantiation)
+        self.assertEqual("add_int", functionInstantiation.Identifier)
+        self.assertIsNotNone(functionInstantiation.SubprogramReference)
+        self.assertEqual(1, len(functionInstantiation.GenericAssociationItems))
+        # ReturnType cannot be resolved without semantic analysis - see class docstring.
+        self.assertIsNone(functionInstantiation.ReturnType)
+
+    def test_ProcedureInstantiation(self) -> None:
+        pkg = self._package()
+        procedureInstantiation = pkg.DeclaredItems[1]
+
+        self.assertIsInstance(procedureInstantiation, ProcedureInstantiation)
+        self.assertEqual("proc_int", procedureInstantiation.Identifier)
+        self.assertIsNotNone(procedureInstantiation.SubprogramReference)
+        self.assertEqual(1, len(procedureInstantiation.GenericAssociationItems))

--- a/testsuite/pyunit/dom/examples/Aliases.vhdl
+++ b/testsuite/pyunit/dom/examples/Aliases.vhdl
@@ -1,0 +1,16 @@
+-- Author: Patrick Lehmann
+--
+-- Alias declarations: object alias with subtype, plain object alias, type alias, and an operator
+-- alias with an explicit signature.
+package Aliases is
+	signal s : bit_vector(7 downto 0);
+
+	alias a : bit_vector(3 downto 0) is s(3 downto 0);
+	alias b is s;
+
+	type Integer2 is range 0 to 100;
+	alias MyInt is Integer2;
+
+	function add(x, y : integer) return integer;
+	alias "+" is add[integer, integer return integer];
+end package Aliases;

--- a/testsuite/pyunit/dom/examples/SubprogramInstantiation.vhdl
+++ b/testsuite/pyunit/dom/examples/SubprogramInstantiation.vhdl
@@ -1,0 +1,25 @@
+-- Author: Patrick Lehmann
+--
+-- VHDL-2008 subprogram instantiation (generic subprograms).
+package Generics is
+	function generic_add generic (type T) (x, y : T) return T;
+	procedure generic_proc generic (type U) (x : U);
+end package Generics;
+
+package body Generics is
+	function generic_add generic (type T) (x, y : T) return T is
+	begin
+		return x + y;
+	end function;
+
+	procedure generic_proc generic (type U) (x : U) is
+	begin
+	end procedure;
+end package body Generics;
+
+use work.Generics.all;
+
+package Instances is
+	function add_int is new work.Generics.generic_add generic map (T => integer);
+	procedure proc_int is new work.Generics.generic_proc generic map (U => integer);
+end package Instances;


### PR DESCRIPTION
## Summary

Companion to VHDL/pyVHDLModel#135. Two independent fixes grouped together: subprogram
instantiation, then alias.

### 1. Subprogram instantiation (VHDL-2008 generic subprograms)

`Function_Instantiation_Declaration`/`Procedure_Instantiation_Declaration` were previously not
handled at all - hard crash (`Unknown declared item kind`).

- `pyGHDL/dom/Symbol.py`: `SubprogramReferenceSymbol`, mirroring `PackageReferenceSymbol`.
- `pyGHDL/dom/Subprogram.py`: `FunctionInstantiation`, `ProcedureInstantiation`, reading
  `Uninstantiated_Subprogram_Name` (handling the Signature-wrapped case the same way `Alias.parse()`
  does - same FIXME about dropped parameter/return type marks) and `Get_Generic_Map_Aspect_Chain`
  via the existing `GetGenericMapAspect` helper.
- `pyGHDL/dom/_Translate.py`: wired both into `GetDeclaredItemsFromChainedNodes`.

Deliberately did **not** read `Get_Return_Type` or `Get_Pure_Flag` for `FunctionInstantiation` -
verified against real GHDL that neither is resolved at the parse-only level this project operates
at (`Get_Pure_Flag` returns `False` even for an actually-pure referenced function). Both are
properties of the referenced uninstantiated function, not the instantiation itself - matches
pyVHDLModel's `FunctionInstantiation.ReturnType`, which is deliberately `Nullable` for this exact
reason.

### 2. Alias

`Alias.parse()` previously did nothing except read the alias's own identifier -
`# FIXME: add an implementation`. Now reads the aliased name and, if present, the subtype
indication.

Confirmed against GHDL's own IIR documentation and empirically: "the parser only creates object
alias declaration nodes" - `Non_Object_Alias_Declaration` is a purely semantic-analysis-time
transformation (done by `sem_decl`) that this parse-only pipeline never triggers. So every alias -
whether aliasing a signal, a slice of a signal, a type, or an operator/subprogram - arrives as a
single `Object_Alias_Declaration` kind here; no second dispatcher branch is needed.

One deliberately-scoped-out edge case: aliasing an overloaded subprogram/operator with an explicit
signature (`alias "+" is add[integer, integer return integer];`) - `Get_Name` returns a `Signature`
node in this case, not a plain `Name`. Extracts just the `Signature_Prefix` (the actual aliased
name) and drops the parameter/return type marks used for disambiguation - flagged with a FIXME
rather than silently dropped without a trace.

Replaced the now-superseded `GetAliasFromNode` helper (which called the old, empty `Alias`
constructor directly) with `Alias.parse()`, and removed the now-unused top-level `Alias` import in
`_Translate.py`.

## Testing

Verified against real GHDL analysis (nightly libghdl build) for both features - subprogram
instantiation with a function and a procedure, each with a generic map association; alias with all
four variants (object alias with subtype, plain object alias, type alias, operator alias with
signature).

Caught a real syntax mistake in my own subprogram-instantiation fixture along the way: VHDL-2008
generic-subprogram syntax puts the generic clause inline between the subprogram name and parameter
list (`function f generic (type T) (x, y : T) return T;`), not as a separate preceding declaration
- found by testing the fixture directly against GHDL rather than assuming.

Added `testsuite/pyunit/dom/SubprogramInstantiation.py` + `examples/SubprogramInstantiation.vhdl`,
and `testsuite/pyunit/dom/Alias.py` + `examples/Aliases.vhdl`. Full suite: `41 passed` (was 35),
5 skipped, no regressions.

## Dependency

Requires https://github.com/VHDL/pyVHDLModel/pull/135 (open).
