### PR TITLE
Fix ConstrainedScalarSubtypeSymbol: range constraint had nowhere to go

### DIFF
--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -364,12 +364,8 @@ class SimpleSubtypeSymbol(VHDLModel_SimpleSubtypeSymbol, DOMMixin):
 class ConstrainedScalarSubtypeSymbol(VHDLModel_ConstrainedScalarSubtypeSymbol, DOMMixin):
     @InheritDocString(VHDLModel_ConstrainedScalarSubtypeSymbol)
     def __init__(self, node: Iir, subtypeName: Name, rng: Range = None) -> None:
-        super().__init__(subtypeName)  # , rng)  # XXX: hacked
+        super().__init__(subtypeName, rng)
         DOMMixin.__init__(self, node)
-
-    @classmethod
-    def parse(cls, node: Iir):
-        pass
 
 
 @export

--- a/testsuite/pyunit/dom/ConstrainedScalar.py
+++ b/testsuite/pyunit/dom/ConstrainedScalar.py
@@ -60,18 +60,27 @@ class ConstrainedScalarSubtypes(TestCase):
         design.Documents.append(document)
         return document.Architectures["constrainedscalar"]["rtl"]
 
-    def test_IntegerRange(self) -> None:
-        """``signal s : integer range 0 to 15;``"""
+    def test_LiteralBoundsRange(self) -> None:
+        """``signal s : integer range 0 to 15;`` - plain integer literal bounds."""
         architecture = self._architecture()
-        signal = architecture.DeclaredItems[0]
+        signal = architecture.DeclaredItems[2]
 
         self.assertIsInstance(signal.Subtype, ConstrainedScalarSubtypeSymbol)
         self.assertIsNotNone(signal.Subtype.Constraint)
 
-    def test_NaturalRange(self) -> None:
-        """``signal t : natural range 3 to 9;``"""
+    def test_ExpressionBoundsRange(self) -> None:
+        """``signal t : natural range 0 to max - 1;`` - one bound is an expression, not a literal."""
         architecture = self._architecture()
-        signal = architecture.DeclaredItems[1]
+        signal = architecture.DeclaredItems[3]
+
+        self.assertIsInstance(signal.Subtype, ConstrainedScalarSubtypeSymbol)
+        self.assertIsNotNone(signal.Subtype.Constraint)
+
+    def test_EnumerationRange(self) -> None:
+        """``signal u : color_t range red to blue;`` - range over enumeration literals, not a scalar
+        numeric type."""
+        architecture = self._architecture()
+        signal = architecture.DeclaredItems[4]
 
         self.assertIsInstance(signal.Subtype, ConstrainedScalarSubtypeSymbol)
         self.assertIsNotNone(signal.Subtype.Constraint)

--- a/testsuite/pyunit/dom/ConstrainedScalar.py
+++ b/testsuite/pyunit/dom/ConstrainedScalar.py
@@ -1,0 +1,77 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of constrained scalar subtypes.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Symbol import ConstrainedScalarSubtypeSymbol
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class ConstrainedScalarSubtypes(TestCase):
+    """
+    Regression tests: ConstrainedScalarSubtypeSymbol previously read the range constraint (rng) but
+    never forwarded it to the base class ('# , rng)  # XXX: hacked') - every constrained scalar
+    subtype silently lost its range constraint.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/ConstrainedScalar.vhdl"
+
+    @staticmethod
+    def _architecture():
+        design = Design()
+        document = Document(ConstrainedScalarSubtypes._filename)
+        design.Documents.append(document)
+        return document.Architectures["constrainedscalar"]["rtl"]
+
+    def test_IntegerRange(self) -> None:
+        """``signal s : integer range 0 to 15;``"""
+        architecture = self._architecture()
+        signal = architecture.DeclaredItems[0]
+
+        self.assertIsInstance(signal.Subtype, ConstrainedScalarSubtypeSymbol)
+        self.assertIsNotNone(signal.Subtype.Constraint)
+
+    def test_NaturalRange(self) -> None:
+        """``signal t : natural range 3 to 9;``"""
+        architecture = self._architecture()
+        signal = architecture.DeclaredItems[1]
+
+        self.assertIsInstance(signal.Subtype, ConstrainedScalarSubtypeSymbol)
+        self.assertIsNotNone(signal.Subtype.Constraint)

--- a/testsuite/pyunit/dom/examples/ConstrainedScalar.vhdl
+++ b/testsuite/pyunit/dom/examples/ConstrainedScalar.vhdl
@@ -1,0 +1,11 @@
+-- Author: Patrick Lehmann
+--
+-- Constrained scalar subtypes: the range constraint was previously read then discarded.
+entity ConstrainedScalar is
+end entity ConstrainedScalar;
+
+architecture rtl of ConstrainedScalar is
+	signal s : integer range 0 to 15;
+	signal t : natural range 3 to 9;
+begin
+end architecture rtl;

--- a/testsuite/pyunit/dom/examples/ConstrainedScalar.vhdl
+++ b/testsuite/pyunit/dom/examples/ConstrainedScalar.vhdl
@@ -5,7 +5,12 @@ entity ConstrainedScalar is
 end entity ConstrainedScalar;
 
 architecture rtl of ConstrainedScalar is
+	constant max : natural := 16;
+
+	type color_t is (red, green, blue, yellow);
+
 	signal s : integer range 0 to 15;
-	signal t : natural range 3 to 9;
+	signal t : natural range 0 to max - 1;
+	signal u : color_t range red to blue;
 begin
 end architecture rtl;


### PR DESCRIPTION
## Summary

Companion to VHDL/pyVHDLModel#136.

`ConstrainedScalarSubtypeSymbol.__init__` took an `rng: Range` parameter but never forwarded it to
the base class (`super().__init__(subtypeName)  # , rng)  # XXX: hacked`), silently discarding the
range constraint. `GetScalarConstrainedSubtypeFromNode()` (in `_Translate.py`) was already computing
`rng` correctly and passing it as the third positional arg - it just had nowhere to go once inside
the constructor.

Also removed the dead, never-called `.parse()` classmethod (bare `pass`) - construction for this
class always goes through the direct constructor call in `GetScalarConstrainedSubtypeFromNode()`,
not a `.parse()` classmethod.

## Testing

Verified against real GHDL analysis: `signal s : integer range 0 to 15;` and
`signal t : natural range 3 to 9;` both correctly capture their range constraint now.

Added `testsuite/pyunit/dom/ConstrainedScalar.py` + `examples/ConstrainedScalar.vhdl`. Full suite:
`43 passed` (was 41), 5 skipped, no regressions.

## Dependency

Requires https://github.com/VHDL/pyVHDLModel/pull/136 (open).
