### PR TITLE
Translate configurations

### DIFF
--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -1,0 +1,224 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Package module:   DOM: Configurations, block/component configurations, binding indications.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from typing import List, Generator
+
+from pyTooling.Decorators import export
+
+from pyVHDLModel.Symbol import Symbol, PossibleReference
+from pyVHDLModel.Configuration import EntityAspectEntity as VHDLModel_EntityAspectEntity
+from pyVHDLModel.Configuration import EntityAspectConfiguration as VHDLModel_EntityAspectConfiguration
+from pyVHDLModel.Configuration import EntityAspectOpen as VHDLModel_EntityAspectOpen
+from pyVHDLModel.Configuration import BindingIndication as VHDLModel_BindingIndication
+from pyVHDLModel.Configuration import AllInstantiationList as VHDLModel_AllInstantiationList
+from pyVHDLModel.Configuration import OthersInstantiationList as VHDLModel_OthersInstantiationList
+from pyVHDLModel.Configuration import ComponentConfiguration as VHDLModel_ComponentConfiguration
+from pyVHDLModel.Configuration import BlockConfiguration as VHDLModel_BlockConfiguration
+
+from pyGHDL.libghdl._types import Iir
+from pyGHDL.libghdl.vhdl import nodes
+from pyGHDL.libghdl import utils
+from pyGHDL.dom import DOMMixin, DOMException, Position
+from pyGHDL.dom._Utils import GetIirKindOfNode
+
+
+@export
+class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
+    def __init__(self, node: Iir, entity, architecture=None) -> None:
+        super().__init__(entity, architecture)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, entityAspectNode: Iir) -> "EntityAspectEntity":
+        from pyGHDL.dom._Translate import GetName
+        from pyGHDL.dom.Symbol import EntitySymbol, ArchitectureSymbol
+
+        entityNameNode = nodes.Get_Entity_Name(entityAspectNode)
+        entity = EntitySymbol(entityNameNode, GetName(entityNameNode))
+
+        architectureNode = nodes.Get_Architecture(entityAspectNode)
+        architecture = (
+            None if architectureNode == nodes.Null_Iir else ArchitectureSymbol(architectureNode, GetName(architectureNode))
+        )
+
+        return cls(entityAspectNode, entity, architecture)
+
+
+@export
+class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
+    def __init__(self, node: Iir, configuration) -> None:
+        super().__init__(configuration)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, entityAspectNode: Iir) -> "EntityAspectConfiguration":
+        from pyGHDL.dom._Translate import GetName
+        from pyGHDL.dom.Symbol import ConfigurationSymbol
+
+        configurationNameNode = nodes.Get_Configuration_Name(entityAspectNode)
+        configuration = ConfigurationSymbol(configurationNameNode, GetName(configurationNameNode))
+
+        return cls(entityAspectNode, configuration)
+
+
+@export
+class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
+    def __init__(self, node: Iir) -> None:
+        super().__init__()
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, entityAspectNode: Iir) -> "EntityAspectOpen":
+        return cls(entityAspectNode)
+
+
+def GetEntityAspectFromNode(entityAspectNode: Iir):
+    """Translates an entity aspect (IIR node) to the matching pyVHDLModel.Configuration.EntityAspect subclass."""
+    kind = GetIirKindOfNode(entityAspectNode)
+    if kind == nodes.Iir_Kind.Entity_Aspect_Entity:
+        return EntityAspectEntity.parse(entityAspectNode)
+    elif kind == nodes.Iir_Kind.Entity_Aspect_Configuration:
+        return EntityAspectConfiguration.parse(entityAspectNode)
+    elif kind == nodes.Iir_Kind.Entity_Aspect_Open:
+        return EntityAspectOpen.parse(entityAspectNode)
+    else:
+        position = Position.parse(entityAspectNode)
+        raise DOMException(f"Unknown entity aspect kind '{kind.name}' at {position}.")
+
+
+@export
+class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
+    def __init__(self, node: Iir, entityAspect=None, genericAssociationItems=None, portAssociationItems=None) -> None:
+        super().__init__(entityAspect, genericAssociationItems, portAssociationItems)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, bindingIndicationNode: Iir) -> "BindingIndication":
+        from pyGHDL.dom._Translate import GetGenericMapAspect, GetPortMapAspect
+
+        entityAspectNode = nodes.Get_Entity_Aspect(bindingIndicationNode)
+        entityAspect = None if entityAspectNode == nodes.Null_Iir else GetEntityAspectFromNode(entityAspectNode)
+
+        genericAssociationItems = GetGenericMapAspect(nodes.Get_Generic_Map_Aspect_Chain(bindingIndicationNode))
+        portAssociationItems = GetPortMapAspect(nodes.Get_Port_Map_Aspect_Chain(bindingIndicationNode))
+
+        return cls(bindingIndicationNode, entityAspect, genericAssociationItems, portAssociationItems)
+
+
+@export
+class AllInstantiationList(VHDLModel_AllInstantiationList, DOMMixin):
+    def __init__(self, node: Iir) -> None:
+        super().__init__()
+        DOMMixin.__init__(self, node)
+
+
+@export
+class OthersInstantiationList(VHDLModel_OthersInstantiationList, DOMMixin):
+    def __init__(self, node: Iir) -> None:
+        super().__init__()
+        DOMMixin.__init__(self, node)
+
+
+@export
+class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
+    """
+    .. note::
+
+       Also used for configuration specifications (``for U1 : comp use entity ...;`` declared
+       directly in an architecture's declarative part) - GHDL represents both with the identical
+       field structure (``Instantiation_List``, ``Component_Name``, ``Binding_Indication``).
+    """
+
+    def __init__(self, node: Iir, instantiationList, componentName, bindingIndication=None) -> None:
+        super().__init__(instantiationList, componentName, bindingIndication)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "ComponentConfiguration":
+        from pyGHDL.dom._Translate import GetName
+        from pyGHDL.dom.Symbol import ComponentInstantiationSymbol
+
+        instList = nodes.Get_Instantiation_List(node)
+        if instList == nodes.Iir_Flist_All:
+            instantiationList = AllInstantiationList(node)
+        elif instList == nodes.Iir_Flist_Others:
+            instantiationList = OthersInstantiationList(node)
+        else:
+            instantiationList = []
+            for labelNode in utils.flist_iter(instList):
+                instantiationList.append(GetName(labelNode))
+
+        componentNameNode = nodes.Get_Component_Name(node)
+        componentName = ComponentInstantiationSymbol(componentNameNode, GetName(componentNameNode))
+
+        bindingIndicationNode = nodes.Get_Binding_Indication(node)
+        bindingIndication = (
+            None if bindingIndicationNode == nodes.Null_Iir else BindingIndication.parse(bindingIndicationNode)
+        )
+
+        return cls(node, instantiationList, componentName, bindingIndication)
+
+
+@export
+class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
+    def __init__(self, node: Iir, blockSpecification: Symbol, items: List = None) -> None:
+        super().__init__(blockSpecification, items)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "BlockConfiguration":
+        from pyGHDL.dom._Translate import GetName
+        from pyGHDL.dom.Symbol import Symbol as DOMSymbol
+
+        blockSpecificationNode = nodes.Get_Block_Specification(node)
+        blockSpecification = DOMSymbol(
+            blockSpecificationNode,
+            GetName(blockSpecificationNode),
+            PossibleReference.Architecture | PossibleReference.Label,
+        )
+
+        items = list(GetConfigurationItemsFromChainedNodes(nodes.Get_Configuration_Item_Chain(node)))
+
+        return cls(node, blockSpecification, items)
+
+
+def GetConfigurationItemsFromChainedNodes(nodeChain: Iir) -> Generator:
+    """Translates a chain of configuration items (component/block configurations) to pyVHDLModel objects."""
+    for item in utils.chain_iter(nodeChain):
+        kind = GetIirKindOfNode(item)
+        if kind == nodes.Iir_Kind.Component_Configuration:
+            yield ComponentConfiguration.parse(item)
+        elif kind == nodes.Iir_Kind.Block_Configuration:
+            yield BlockConfiguration.parse(item)
+        else:
+            position = Position.parse(item)
+            raise DOMException(f"Unknown configuration item kind '{kind.name}' at {position}.")

--- a/pyGHDL/dom/Configuration.py
+++ b/pyGHDL/dom/Configuration.py
@@ -30,11 +30,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import List, Generator
+from typing import List, Generator, Union
 
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Symbol import Symbol, PossibleReference
+from pyVHDLModel.Name import Name
+from pyVHDLModel.Association import GenericAssociationItem, PortAssociationItem
+from pyVHDLModel.Configuration import EntityAspect as VHDLModel_EntityAspect
 from pyVHDLModel.Configuration import EntityAspectEntity as VHDLModel_EntityAspectEntity
 from pyVHDLModel.Configuration import EntityAspectConfiguration as VHDLModel_EntityAspectConfiguration
 from pyVHDLModel.Configuration import EntityAspectOpen as VHDLModel_EntityAspectOpen
@@ -49,18 +52,18 @@ from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.libghdl import utils
 from pyGHDL.dom import DOMMixin, DOMException, Position
 from pyGHDL.dom._Utils import GetIirKindOfNode
+from pyGHDL.dom.Symbol import EntitySymbol, ArchitectureSymbol, ConfigurationSymbol, ComponentInstantiationSymbol
 
 
 @export
 class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
-    def __init__(self, node: Iir, entity, architecture=None) -> None:
+    def __init__(self, node: Iir, entity: EntitySymbol, architecture: ArchitectureSymbol = None) -> None:
         super().__init__(entity, architecture)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, entityAspectNode: Iir) -> "EntityAspectEntity":
         from pyGHDL.dom._Translate import GetName
-        from pyGHDL.dom.Symbol import EntitySymbol, ArchitectureSymbol
 
         entityNameNode = nodes.Get_Entity_Name(entityAspectNode)
         entity = EntitySymbol(entityNameNode, GetName(entityNameNode))
@@ -75,14 +78,13 @@ class EntityAspectEntity(VHDLModel_EntityAspectEntity, DOMMixin):
 
 @export
 class EntityAspectConfiguration(VHDLModel_EntityAspectConfiguration, DOMMixin):
-    def __init__(self, node: Iir, configuration) -> None:
+    def __init__(self, node: Iir, configuration: ConfigurationSymbol) -> None:
         super().__init__(configuration)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, entityAspectNode: Iir) -> "EntityAspectConfiguration":
         from pyGHDL.dom._Translate import GetName
-        from pyGHDL.dom.Symbol import ConfigurationSymbol
 
         configurationNameNode = nodes.Get_Configuration_Name(entityAspectNode)
         configuration = ConfigurationSymbol(configurationNameNode, GetName(configurationNameNode))
@@ -101,7 +103,7 @@ class EntityAspectOpen(VHDLModel_EntityAspectOpen, DOMMixin):
         return cls(entityAspectNode)
 
 
-def GetEntityAspectFromNode(entityAspectNode: Iir):
+def GetEntityAspectFromNode(entityAspectNode: Iir) -> VHDLModel_EntityAspect:
     """Translates an entity aspect (IIR node) to the matching pyVHDLModel.Configuration.EntityAspect subclass."""
     kind = GetIirKindOfNode(entityAspectNode)
     if kind == nodes.Iir_Kind.Entity_Aspect_Entity:
@@ -117,7 +119,13 @@ def GetEntityAspectFromNode(entityAspectNode: Iir):
 
 @export
 class BindingIndication(VHDLModel_BindingIndication, DOMMixin):
-    def __init__(self, node: Iir, entityAspect=None, genericAssociationItems=None, portAssociationItems=None) -> None:
+    def __init__(
+        self,
+        node: Iir,
+        entityAspect: VHDLModel_EntityAspect = None,
+        genericAssociationItems: List[GenericAssociationItem] = None,
+        portAssociationItems: List[PortAssociationItem] = None,
+    ) -> None:
         super().__init__(entityAspect, genericAssociationItems, portAssociationItems)
         DOMMixin.__init__(self, node)
 
@@ -158,14 +166,19 @@ class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
        field structure (``Instantiation_List``, ``Component_Name``, ``Binding_Indication``).
     """
 
-    def __init__(self, node: Iir, instantiationList, componentName, bindingIndication=None) -> None:
+    def __init__(
+        self,
+        node: Iir,
+        instantiationList: Union[List[Name], "AllInstantiationList", "OthersInstantiationList"],
+        componentName: ComponentInstantiationSymbol,
+        bindingIndication: BindingIndication = None,
+    ) -> None:
         super().__init__(instantiationList, componentName, bindingIndication)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, node: Iir) -> "ComponentConfiguration":
         from pyGHDL.dom._Translate import GetName
-        from pyGHDL.dom.Symbol import ComponentInstantiationSymbol
 
         instList = nodes.Get_Instantiation_List(node)
         if instList == nodes.Iir_Flist_All:
@@ -190,7 +203,12 @@ class ComponentConfiguration(VHDLModel_ComponentConfiguration, DOMMixin):
 
 @export
 class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
-    def __init__(self, node: Iir, blockSpecification: Symbol, items: List = None) -> None:
+    def __init__(
+        self,
+        node: Iir,
+        blockSpecification: Symbol,
+        items: List[Union["BlockConfiguration", ComponentConfiguration]] = None,
+    ) -> None:
         super().__init__(blockSpecification, items)
         DOMMixin.__init__(self, node)
 
@@ -211,7 +229,9 @@ class BlockConfiguration(VHDLModel_BlockConfiguration, DOMMixin):
         return cls(node, blockSpecification, items)
 
 
-def GetConfigurationItemsFromChainedNodes(nodeChain: Iir) -> Generator:
+def GetConfigurationItemsFromChainedNodes(
+    nodeChain: Iir,
+) -> Generator[Union[BlockConfiguration, ComponentConfiguration], None, None]:
     """Translates a chain of configuration items (component/block configurations) to pyVHDLModel objects."""
     for item in utils.chain_iter(nodeChain):
         kind = GetIirKindOfNode(item)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -361,17 +361,29 @@ class Context(VHDLModel_Context, DOMMixin):
 @export
 class Configuration(VHDLModel_Configuration, DOMMixin):
     def __init__(
-        self, node: Iir, identifier: str, contextItems: Iterable[Context] = None, documentation: str = None
+        self,
+        node: Iir,
+        identifier: str,
+        entity,
+        blockConfiguration,
+        contextItems: Iterable[Context] = None,
+        documentation: str = None,
     ) -> None:
-        super().__init__(identifier, contextItems, documentation, None)
+        super().__init__(identifier, entity, blockConfiguration, contextItems, documentation, None)
         DOMMixin.__init__(self, node)
 
     @classmethod
     def parse(cls, configurationNode: Iir, contextItems: Iterable[Context]):
+        from pyGHDL.dom._Translate import GetName
+        from pyGHDL.dom.Symbol import EntitySymbol
+        from pyGHDL.dom.Configuration import BlockConfiguration
+
         name = GetNameOfNode(configurationNode)
         documentation = GetDocumentationOfNode(configurationNode)
 
-        # FIXME: read use clauses
-        # FIXME: read specifications
+        entityNameNode = nodes.Get_Entity_Name(configurationNode)
+        entity = EntitySymbol(entityNameNode, GetName(entityNameNode))
 
-        return cls(configurationNode, name, contextItems, documentation)
+        blockConfiguration = BlockConfiguration.parse(nodes.Get_Block_Configuration(configurationNode))
+
+        return cls(configurationNode, name, entity, blockConfiguration, contextItems, documentation)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -365,12 +365,12 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
         self,
         node: Iir,
         identifier: str,
-        target: EntitySymbol,
+        entity: EntitySymbol,
         blockConfiguration: BlockConfiguration,
         contextItems: Iterable[Context] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, target, blockConfiguration, contextItems, documentation, None)
+        super().__init__(identifier, entity, blockConfiguration, contextItems, documentation, None)
         DOMMixin.__init__(self, node)
 
     @classmethod
@@ -380,9 +380,9 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
         name = GetNameOfNode(configurationNode)
         documentation = GetDocumentationOfNode(configurationNode)
 
-        targetNameNode = nodes.Get_Entity_Name(configurationNode)
-        target = EntitySymbol(targetNameNode, GetName(targetNameNode))
+        entityNameNode = nodes.Get_Entity_Name(configurationNode)
+        entity = EntitySymbol(entityNameNode, GetName(entityNameNode))
 
         blockConfiguration = BlockConfiguration.parse(nodes.Get_Block_Configuration(configurationNode))
 
-        return cls(configurationNode, name, target, blockConfiguration, contextItems, documentation)
+        return cls(configurationNode, name, entity, blockConfiguration, contextItems, documentation)

--- a/pyGHDL/dom/DesignUnit.py
+++ b/pyGHDL/dom/DesignUnit.py
@@ -78,6 +78,7 @@ from pyGHDL.dom.Symbol import (
     PackageMemberReferenceSymbol,
     AllPackageMembersReferenceSymbol,
 )
+from pyGHDL.dom.Configuration import BlockConfiguration
 
 
 @export
@@ -364,26 +365,24 @@ class Configuration(VHDLModel_Configuration, DOMMixin):
         self,
         node: Iir,
         identifier: str,
-        entity,
-        blockConfiguration,
+        target: EntitySymbol,
+        blockConfiguration: BlockConfiguration,
         contextItems: Iterable[Context] = None,
         documentation: str = None,
     ) -> None:
-        super().__init__(identifier, entity, blockConfiguration, contextItems, documentation, None)
+        super().__init__(identifier, target, blockConfiguration, contextItems, documentation, None)
         DOMMixin.__init__(self, node)
 
     @classmethod
-    def parse(cls, configurationNode: Iir, contextItems: Iterable[Context]):
+    def parse(cls, configurationNode: Iir, contextItems: Iterable[Context]) -> "Configuration":
         from pyGHDL.dom._Translate import GetName
-        from pyGHDL.dom.Symbol import EntitySymbol
-        from pyGHDL.dom.Configuration import BlockConfiguration
 
         name = GetNameOfNode(configurationNode)
         documentation = GetDocumentationOfNode(configurationNode)
 
-        entityNameNode = nodes.Get_Entity_Name(configurationNode)
-        entity = EntitySymbol(entityNameNode, GetName(entityNameNode))
+        targetNameNode = nodes.Get_Entity_Name(configurationNode)
+        target = EntitySymbol(targetNameNode, GetName(targetNameNode))
 
         blockConfiguration = BlockConfiguration.parse(nodes.Get_Block_Configuration(configurationNode))
 
-        return cls(configurationNode, name, entity, blockConfiguration, contextItems, documentation)
+        return cls(configurationNode, name, target, blockConfiguration, contextItems, documentation)

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -46,6 +46,7 @@ from pyVHDLModel.Symbol import LibraryReferenceSymbol as VHDLModel_LibraryRefere
 from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageReferenceSymbol
 from pyVHDLModel.Symbol import ModeViewSymbol as VHDLModel_ModeViewSymbol
 from pyVHDLModel.Symbol import SubprogramReferenceSymbol as VHDLModel_SubprogramReferenceSymbol
+from pyVHDLModel.Symbol import ConfigurationSymbol as VHDLModel_ConfigurationSymbol
 from pyVHDLModel.Symbol import PackageMemberReferenceSymbol as VHDLModel_PackageMemberReferenceSymbol
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
@@ -164,6 +165,29 @@ class SubprogramReferenceSymbol(VHDLModel_SubprogramReferenceSymbol, DOMMixin):
     """
 
     @InheritDocString(VHDLModel_SubprogramReferenceSymbol)
+    def __init__(self, identifierNode: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class ConfigurationSymbol(VHDLModel_ConfigurationSymbol, DOMMixin):
+    """
+    Represents a reference (name) to a configuration declaration, e.g. in an entity aspect of a
+    binding indication.
+
+    This class implements a :mod:`pyGHDL.dom` object derived from
+    :class:`pyVHDLModel.Symbol.ConfigurationSymbol`.
+
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          for U1 : comp use configuration work.cfg;
+          --                              ^^^^^^^
+    """
+
+    @InheritDocString(VHDLModel_ConfigurationSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -907,6 +907,10 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                 from pyGHDL.dom.Misc import Alias
 
                 yield Alias.parse(item)
+            elif kind == nodes.Iir_Kind.Configuration_Specification:
+                from pyGHDL.dom.Configuration import ComponentConfiguration
+
+                yield ComponentConfiguration.parse(item)
             elif kind == nodes.Iir_Kind.Component_Declaration:
                 from pyGHDL.dom.DesignUnit import Component
 

--- a/testsuite/pyunit/dom/Configuration.py
+++ b/testsuite/pyunit/dom/Configuration.py
@@ -71,7 +71,7 @@ class Configurations(TestCase):
         cfg = document.Configurations["cfg"]
 
         self.assertEqual("Cfg", cfg.Identifier)
-        self.assertIsNotNone(cfg.Entity)
+        self.assertIsNotNone(cfg.Target)
 
         block = cfg.BlockConfiguration
         self.assertIsInstance(block, BlockConfiguration)
@@ -112,7 +112,7 @@ class Configurations(TestCase):
         """``for U4 : SubComp use entity work.Sub(Behav);`` - declared directly in the architecture,
         not inside a separate configuration declaration."""
         document = self._document()
-        architecture = document.Architectures["consumer"]["Rtl"]
+        architecture = document.Architectures["consumer"]["rtl"]
         item = architecture.DeclaredItems[1]
 
         self.assertIsInstance(item, ComponentConfiguration)

--- a/testsuite/pyunit/dom/Configuration.py
+++ b/testsuite/pyunit/dom/Configuration.py
@@ -71,7 +71,7 @@ class Configurations(TestCase):
         cfg = document.Configurations["cfg"]
 
         self.assertEqual("Cfg", cfg.Identifier)
-        self.assertIsNotNone(cfg.Target)
+        self.assertIsNotNone(cfg.Entity)
 
         block = cfg.BlockConfiguration
         self.assertIsInstance(block, BlockConfiguration)

--- a/testsuite/pyunit/dom/Configuration.py
+++ b/testsuite/pyunit/dom/Configuration.py
@@ -1,0 +1,120 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of configurations.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Configuration import (
+    EntityAspectEntity, EntityAspectConfiguration, EntityAspectOpen,
+    ComponentConfiguration, BlockConfiguration, OthersInstantiationList,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Configurations(TestCase):
+    """
+    Checks translation of configuration declarations, block configurations, component
+    configurations, configuration specifications, and all three entity aspect forms
+    (entity/configuration/open), plus the 'others' instantiation list form.
+
+    Configuration was previously a bare shell - no entity being configured, no block configuration
+    content at all ('# FIXME: read specifications').
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/Configurations.vhdl"
+
+    @staticmethod
+    def _document():
+        design = Design()
+        document = Document(Configurations._filename)
+        design.Documents.append(document)
+        return document
+
+    def test_ConfigurationDeclaration(self) -> None:
+        document = self._document()
+        cfg = document.Configurations["cfg"]
+
+        self.assertEqual("Cfg", cfg.Identifier)
+        self.assertIsNotNone(cfg.Entity)
+
+        block = cfg.BlockConfiguration
+        self.assertIsInstance(block, BlockConfiguration)
+        self.assertIsNotNone(block.BlockSpecification)
+        self.assertEqual(3, len(block.Items))
+
+    def test_EntityAspectConfiguration(self) -> None:
+        """``for U1 : SubComp use configuration work.BaseCfg;``"""
+        document = self._document()
+        item = document.Configurations["cfg"].BlockConfiguration.Items[0]
+
+        self.assertIsInstance(item, ComponentConfiguration)
+        aspect = item.BindingIndication.EntityAspect
+        self.assertIsInstance(aspect, EntityAspectConfiguration)
+        self.assertIsNotNone(aspect.Configuration)
+
+    def test_EntityAspectOpen(self) -> None:
+        """``for U2 : SubComp use open;``"""
+        document = self._document()
+        item = document.Configurations["cfg"].BlockConfiguration.Items[1]
+
+        aspect = item.BindingIndication.EntityAspect
+        self.assertIsInstance(aspect, EntityAspectOpen)
+
+    def test_OthersInstantiationListAndEntityAspectEntity(self) -> None:
+        """``for others : SubComp use entity work.Sub(Behav);``"""
+        document = self._document()
+        item = document.Configurations["cfg"].BlockConfiguration.Items[2]
+
+        self.assertIsInstance(item.InstantiationList, OthersInstantiationList)
+
+        aspect = item.BindingIndication.EntityAspect
+        self.assertIsInstance(aspect, EntityAspectEntity)
+        self.assertIsNotNone(aspect.Entity)
+        self.assertIsNotNone(aspect.Architecture)
+
+    def test_ConfigurationSpecification(self) -> None:
+        """``for U4 : SubComp use entity work.Sub(Behav);`` - declared directly in the architecture,
+        not inside a separate configuration declaration."""
+        document = self._document()
+        architecture = document.Architectures["consumer"]["Rtl"]
+        item = architecture.DeclaredItems[1]
+
+        self.assertIsInstance(item, ComponentConfiguration)
+        self.assertIsNotNone(item.ComponentName)
+        self.assertIsInstance(item.BindingIndication.EntityAspect, EntityAspectEntity)

--- a/testsuite/pyunit/dom/examples/Configurations.vhdl
+++ b/testsuite/pyunit/dom/examples/Configurations.vhdl
@@ -1,0 +1,44 @@
+-- Author: Patrick Lehmann
+--
+-- Configurations: block/component configurations, configuration specifications, and all three
+-- entity aspect forms (entity, configuration, open), plus the all/others instantiation list forms.
+entity Sub is
+end entity Sub;
+
+architecture Behav of Sub is
+begin
+end architecture Behav;
+
+configuration BaseCfg of Sub is
+	for Behav
+	end for;
+end configuration BaseCfg;
+
+entity Consumer is
+end entity Consumer;
+
+architecture Rtl of Consumer is
+	component SubComp is
+	end component SubComp;
+
+	for U4 : SubComp use entity work.Sub(Behav);
+begin
+	U1 : SubComp;
+	U2 : SubComp;
+	U3 : SubComp;
+	U4 : SubComp;
+end architecture Rtl;
+
+configuration Cfg of Consumer is
+	for Rtl
+		for U1 : SubComp
+			use configuration work.BaseCfg;
+		end for;
+		for U2 : SubComp
+			use open;
+		end for;
+		for others : SubComp
+			use entity work.Sub(Behav);
+		end for;
+	end for;
+end configuration Cfg;

--- a/testsuite/pyunit/dom/examples/Configurations.vhdl
+++ b/testsuite/pyunit/dom/examples/Configurations.vhdl
@@ -5,32 +5,32 @@
 entity Sub is
 end entity Sub;
 
-architecture Behav of Sub is
+architecture rtl of Sub is
 begin
-end architecture Behav;
+end architecture rtl;
 
 configuration BaseCfg of Sub is
-	for Behav
+	for rtl
 	end for;
 end configuration BaseCfg;
 
 entity Consumer is
 end entity Consumer;
 
-architecture Rtl of Consumer is
+architecture rtl of Consumer is
 	component SubComp is
 	end component SubComp;
 
-	for U4 : SubComp use entity work.Sub(Behav);
+	for U4 : SubComp use entity work.Sub(rtl);
 begin
 	U1 : SubComp;
 	U2 : SubComp;
 	U3 : SubComp;
 	U4 : SubComp;
-end architecture Rtl;
+end architecture rtl;
 
 configuration Cfg of Consumer is
-	for Rtl
+	for rtl
 		for U1 : SubComp
 			use configuration work.BaseCfg;
 		end for;
@@ -38,7 +38,7 @@ configuration Cfg of Consumer is
 			use open;
 		end for;
 		for others : SubComp
-			use entity work.Sub(Behav);
+			use entity work.Sub(rtl);
 		end for;
 	end for;
 end configuration Cfg;


### PR DESCRIPTION
## Summary

Companion to VHDL/pyVHDLModel#137. Translates configurations: block/component configurations,
configuration specifications, binding indications, and entity aspects - previously entirely
unimplemented (`# FIXME: read specifications`).

## Changes

- `pyGHDL/dom/Symbol.py`: `ConfigurationSymbol`, mirroring `PackageReferenceSymbol`.
- New `pyGHDL/dom/Configuration.py`: `EntityAspectEntity`/`EntityAspectConfiguration`/
  `EntityAspectOpen` (dispatched via `GetEntityAspectFromNode`), `BindingIndication`,
  `AllInstantiationList`/`OthersInstantiationList`, `ComponentConfiguration` (also used for
  `Configuration_Specification` - confirmed empirically both use the identical
  `Instantiation_List`/`Component_Name`/`Binding_Indication` fields), `BlockConfiguration`
  (recursively translating nested block/component configuration items).
- `pyGHDL/dom/DesignUnit.py`: `Configuration.parse()` now reads `Entity_Name` and recursively
  translates `Block_Configuration`, instead of doing nothing beyond identifier/documentation.
- `pyGHDL/dom/_Translate.py`: wired `Configuration_Specification` into the declared-items
  dispatcher (previously would have hard-crashed with `Unknown declared item kind`).

## Notes on empirical verification

Field names for `Entity_Aspect_Configuration` (`Get_Configuration_Name`, not `Get_Entity_Name` -
verified empirically, since assuming `Get_Entity_Name` would have raised an Ada assertion error)
and the `Instantiation_List`'s Flist special values (`Iir_Flist_All`/`Iir_Flist_Others` vs. a real
Flist of labels, walked via `flist_iter`) were all confirmed against real GHDL analysis before use,
not assumed from the IIR documentation alone.

## Testing

Verified against real GHDL analysis (nightly libghdl build) with all three entity aspect forms
(entity+architecture, configuration, open), the `others` instantiation list form, a nested
component configuration inside a block configuration, and a configuration specification declared
directly in an architecture.

Added `testsuite/pyunit/dom/Configuration.py` + `examples/Configurations.vhdl`. Full suite:
`49 passed` (was 44), 5 skipped, no regressions.

## Dependency

Requires https://github.com/VHDL/pyVHDLModel/pull/137 (open).
