### PR TITLE
Fix generate-statement alternative labels and bit-string literal signed/length metadata

### DIFF
--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -67,7 +67,7 @@ from pyVHDLModel.Concurrent import (
     RangedGenerateChoice as VHDLModel_RangedGenerateChoice,
 )
 
-from pyGHDL.libghdl import Iir, utils
+from pyGHDL.libghdl import Iir, utils, name_table
 from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, DOMException, Position
 from pyGHDL.dom.Range import Range
@@ -268,9 +268,8 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
         condition = GetExpressionFromNode(nodes.Get_Condition(generateNode))
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        # TODO: alternative label
-        # alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = ""
+        alternativeLabelId = nodes.Get_Alternative_Label(body)
+        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "if-generate branch", alternativeLabel)
@@ -305,9 +304,8 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
         condition = GetExpressionFromNode(condition)
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        # TODO: alternative label
-        # alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = ""
+        alternativeLabelId = nodes.Get_Alternative_Label(body)
+        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "elsif-generate branch", alternativeLabel)
@@ -339,9 +337,8 @@ class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
 
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        # TODO: alternative label
-        # alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = ""
+        alternativeLabelId = nodes.Get_Alternative_Label(body)
+        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "else-generate branch", alternativeLabel)
@@ -423,9 +420,8 @@ class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
 
         body = nodes.Get_Associated_Block(caseNode)
 
-        # TODO: alternative label
-        # alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = ""
+        alternativeLabelId = nodes.Get_Alternative_Label(body)
+        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "generate case", alternativeLabel)
@@ -457,9 +453,8 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
 
         body = nodes.Get_Associated_Block(caseNode)
 
-        # TODO: alternative label
-        # alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = ""
+        alternativeLabelId = nodes.Get_Alternative_Label(body)
+        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "case-generate others", alternativeLabel)
@@ -536,7 +531,7 @@ class CaseGenerateStatement(VHDLModel_CaseGenerateStatement, DOMMixin):
                     continue
             elif choiceKind is nodes.Iir_Kind.Choice_By_Others:
                 if choices is not None:
-                    cases.append(GenerateCase.parse(alternative, choices))
+                    cases.append(GenerateCase.parse(caseNode, choices))
                     choices = None
                 cases.append(OthersGenerateCase.parse(alternative))
                 alternative = nodes.Get_Chain(alternative)

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -79,6 +79,17 @@ from pyGHDL.dom.Symbol import (
 )
 
 
+def GetAlternativeLabel(node: Iir) -> Nullable[str]:
+    """
+    Reads the optional alternative label of a generate-statement branch (``Get_Alternative_Label``
+    on a ``Generate_Statement_Body``) or a case-generate alternative (on the node returned by
+    ``Get_Associated_Block``), returning ``None`` if no label was given in the source rather than
+    an empty string.
+    """
+    alternativeLabelId = nodes.Get_Alternative_Label(node)
+    return None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+
+
 @export
 class GenericAssociationItem(VHDLModel_GenericAssociationItem, DOMMixin):
     def __init__(self, associationNode: Iir, formal: Symbol, actual: ExpressionUnion) -> None:
@@ -268,8 +279,7 @@ class IfGenerateBranch(VHDLModel_IfGenerateBranch, DOMMixin):
         condition = GetExpressionFromNode(nodes.Get_Condition(generateNode))
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+        alternativeLabel = GetAlternativeLabel(body)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "if-generate branch", alternativeLabel)
@@ -304,8 +314,7 @@ class ElsifGenerateBranch(VHDLModel_ElsifGenerateBranch, DOMMixin):
         condition = GetExpressionFromNode(condition)
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+        alternativeLabel = GetAlternativeLabel(body)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "elsif-generate branch", alternativeLabel)
@@ -337,8 +346,7 @@ class ElseGenerateBranch(VHDLModel_ElseGenerateBranch, DOMMixin):
 
         body = nodes.Get_Generate_Statement_Body(generateNode)
 
-        alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+        alternativeLabel = GetAlternativeLabel(body)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "else-generate branch", alternativeLabel)
@@ -420,8 +428,7 @@ class GenerateCase(VHDLModel_GenerateCase, DOMMixin):
 
         body = nodes.Get_Associated_Block(caseNode)
 
-        alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+        alternativeLabel = GetAlternativeLabel(body)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "generate case", alternativeLabel)
@@ -453,8 +460,7 @@ class OthersGenerateCase(VHDLModel_OthersGenerateCase, DOMMixin):
 
         body = nodes.Get_Associated_Block(caseNode)
 
-        alternativeLabelId = nodes.Get_Alternative_Label(body)
-        alternativeLabel = None if alternativeLabelId == name_table.Null_Identifier else name_table.Get_Name_Ptr(alternativeLabelId)
+        alternativeLabel = GetAlternativeLabel(body)
 
         declarationChain = nodes.Get_Declaration_Chain(body)
         declaredItems = GetDeclaredItemsFromChainedNodes(declarationChain, "case-generate others", alternativeLabel)

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import Union
+from typing import Union, Optional as Nullable
 
 from pyTooling.Decorators import export
 from pyTooling.Warning import WarningCollector
@@ -147,28 +147,28 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 
 @export
 class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+    def __init__(self, node: Iir, value: str, length: Nullable[int] = None, signed: Nullable[bool] = None) -> None:
         super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+    def __init__(self, node: Iir, value: str, length: Nullable[int] = None, signed: Nullable[bool] = None) -> None:
         super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+    def __init__(self, node: Iir, value: str, length: Nullable[int] = None, signed: Nullable[bool] = None) -> None:
         super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+    def __init__(self, node: Iir, value: str, length: Nullable[int] = None, signed: Nullable[bool] = None) -> None:
         super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 

--- a/pyGHDL/dom/Literal.py
+++ b/pyGHDL/dom/Literal.py
@@ -147,29 +147,29 @@ class CharacterLiteral(VHDLModel_CharacterLiteral, DOMMixin):
 
 @export
 class BinaryBitStringLiteral(VHDLModel_BinaryBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str) -> None:
-        super().__init__(value)
+    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+        super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class OctalBitStringLiteral(VHDLModel_OctalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str) -> None:
-        super().__init__(value)
+    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+        super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class DecimalBitStringLiteral(VHDLModel_DecimalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str) -> None:
-        super().__init__(value)
+    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+        super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
 @export
 class HexadecimalBitStringLiteral(VHDLModel_HexadecimalBitStringLiteral, DOMMixin):
-    def __init__(self, node: Iir, value: str) -> None:
-        super().__init__(value)
+    def __init__(self, node: Iir, value: str, length: int = None, signed: bool = None) -> None:
+        super().__init__(value, length, signed)
         DOMMixin.__init__(self, node)
 
 
@@ -194,22 +194,20 @@ class StringLiteral(VHDLModel_StringLiteral, DOMMixin):
         # sourceIdentifier = utils.Get_Source_Identifier(literalNode)
         # test = name_table.Get_Name_Ptr(sourceIdentifier)
 
-        # TODO: add support for signed and unsigned BitStringLiteral
-        # TODO: add support for BitStringLiteral lengths
         if base is nodes.NumberBaseType.Base_None:
             value = str_table.Get_String8_Ptr(nodes.Get_String8_Id(literalNode), nodes.Get_String_Length(literalNode))
             return cls(literalNode, value)
         elif base is nodes.NumberBaseType.Base_2:
             value = str_table.Get_String8_Ptr(nodes.Get_String8_Id(literalNode), nodes.Get_String_Length(literalNode))
-            return BinaryBitStringLiteral(literalNode, value)
+            return BinaryBitStringLiteral(literalNode, value, length, signed)
         elif base is nodes.NumberBaseType.Base_8:
             value = str_table.Get_String8_Ptr(nodes.Get_String8_Id(literalNode), nodes.Get_String_Length(literalNode))
-            return OctalBitStringLiteral(literalNode, value)
+            return OctalBitStringLiteral(literalNode, value, length, signed)
         elif base is nodes.NumberBaseType.Base_10:
             value = str_table.Get_String8_Ptr(nodes.Get_String8_Id(literalNode), nodes.Get_String_Length(literalNode))
-            return DecimalBitStringLiteral(literalNode, value)
+            return DecimalBitStringLiteral(literalNode, value, length, signed)
         elif base is nodes.NumberBaseType.Base_16:
             value = str_table.Get_String8_Ptr(nodes.Get_String8_Id(literalNode), nodes.Get_String_Length(literalNode))
-            return HexadecimalBitStringLiteral(literalNode, value)
+            return HexadecimalBitStringLiteral(literalNode, value, length, signed)
         else:
             WarningCollector.Raise(NotImplementedError("Bit String Literal not supported yet"))

--- a/testsuite/pyunit/dom/Generate.py
+++ b/testsuite/pyunit/dom/Generate.py
@@ -1,0 +1,93 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of generate-statement alternative labels.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class GenerateAlternativeLabels(TestCase):
+    """
+    Regression tests: generate-statement alternative labels (if/elsif/else branches, case-generate
+    alternatives) were always read as an empty string ('# TODO: alternative label'), regardless of
+    whether the source actually gave one - and there was no way to tell "no label given" apart from
+    "label happens to be empty".
+
+    Also caught a real, independent, pre-existing bug while testing this: when a case-generate
+    alternative was immediately followed by 'others' with no other cases in between, the wrong IIR
+    node was passed to GenerateCase.parse() (the already-advanced 'others' node instead of the
+    original case's node), corrupting that case's label (and, by the same mechanism, its declared
+    items/statements).
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/GenerateLabels.vhdl"
+
+    @staticmethod
+    def _architecture():
+        design = Design()
+        document = Document(GenerateAlternativeLabels._filename)
+        design.Documents.append(document)
+        return document.Architectures["generatelabels"]["rtl"]
+
+    def test_IfBranchWithLabel(self) -> None:
+        """``if label_a : true generate``"""
+        architecture = self._architecture()
+        statement = architecture.Statements[0]
+
+        self.assertEqual("label_a", statement.IfBranch.AlternativeLabel)
+
+    def test_IfBranchWithoutLabel_ElsifAndElseWithLabels(self) -> None:
+        """``if false generate elsif label_b : true generate ... else label_c : generate``"""
+        architecture = self._architecture()
+        statement = architecture.Statements[1]
+
+        self.assertIsNone(statement.IfBranch.AlternativeLabel)
+        self.assertEqual("label_b", statement.ElsifBranches[0].AlternativeLabel)
+        self.assertEqual("label_c", statement.ElseBranch.AlternativeLabel)
+
+    def test_CaseGenerateAlternatives(self) -> None:
+        """``when case_label : 1 => ... when others_label : others =>`` - also confirms the
+        immediately-followed-by-others fix: without it, both cases would show 'others_label'."""
+        architecture = self._architecture()
+        statement = architecture.Statements[2]
+
+        case, othersCase = statement.Cases
+        self.assertEqual("case_label", case.Label)
+        self.assertEqual("others_label", othersCase.Label)

--- a/testsuite/pyunit/dom/Literals.py
+++ b/testsuite/pyunit/dom/Literals.py
@@ -88,3 +88,45 @@ class Literals(TestCase):
 
         self.assertIsInstance(default, IntegerLiteral)
         self.assertEqual(expected[0], default.Value)
+
+    def test_BitStringLiteral_PlainHex(self):
+        """``x"F"`` - no sign, no explicit length. Regression test: Signed/Length were computed from
+        the IIR node but never forwarded to the constructed literal object - always silently None."""
+        from pyGHDL.dom.Literal import HexadecimalBitStringLiteral
+
+        _filename: Path = self._root / "{className}_PlainHex.vhdl".format(className=self.__class__.__name__)
+        default: ExpressionUnion = self.parse(_filename, 'constant c0 : bit_vector(3 downto 0) := x"F";')
+
+        self.assertIsInstance(default, HexadecimalBitStringLiteral)
+        self.assertIsNone(default.Signed)
+        self.assertIsNone(default.Length)
+
+    def test_BitStringLiteral_Signed(self):
+        """``sx"F"``"""
+        from pyGHDL.dom.Literal import HexadecimalBitStringLiteral
+
+        _filename: Path = self._root / "{className}_Signed.vhdl".format(className=self.__class__.__name__)
+        default: ExpressionUnion = self.parse(_filename, 'constant c0 : bit_vector(7 downto 0) := sx"F";')
+
+        self.assertIsInstance(default, HexadecimalBitStringLiteral)
+        self.assertTrue(default.Signed)
+
+    def test_BitStringLiteral_Unsigned(self):
+        """``ux"F"``"""
+        from pyGHDL.dom.Literal import HexadecimalBitStringLiteral
+
+        _filename: Path = self._root / "{className}_Unsigned.vhdl".format(className=self.__class__.__name__)
+        default: ExpressionUnion = self.parse(_filename, 'constant c0 : bit_vector(7 downto 0) := ux"F";')
+
+        self.assertIsInstance(default, HexadecimalBitStringLiteral)
+        self.assertFalse(default.Signed)
+
+    def test_BitStringLiteral_ExplicitLength(self):
+        """``4x"F"``"""
+        from pyGHDL.dom.Literal import HexadecimalBitStringLiteral
+
+        _filename: Path = self._root / "{className}_ExplicitLength.vhdl".format(className=self.__class__.__name__)
+        default: ExpressionUnion = self.parse(_filename, 'constant c0 : bit_vector(3 downto 0) := 4x"F";')
+
+        self.assertIsInstance(default, HexadecimalBitStringLiteral)
+        self.assertEqual(4, default.Length)

--- a/testsuite/pyunit/dom/examples/GenerateLabels.vhdl
+++ b/testsuite/pyunit/dom/examples/GenerateLabels.vhdl
@@ -1,0 +1,27 @@
+-- Author: Patrick Lehmann
+--
+-- Generate statement alternative labels: previously always read as an empty string, regardless of
+-- whether the source gave one or not.
+entity GenerateLabels is
+end entity GenerateLabels;
+
+architecture rtl of GenerateLabels is
+begin
+	gen1: if label_a : true generate
+	begin
+	end generate;
+
+	gen2: if false generate
+	elsif label_b : true generate
+	begin
+	else label_c : generate
+	begin
+	end generate;
+
+	gen3: case 1 generate
+	when case_label : 1 =>
+	begin
+	when others_label : others =>
+	begin
+	end generate;
+end architecture rtl;


### PR DESCRIPTION
## Summary

Two independent fixes bundled together, both entirely on the pyGHDL.dom side - no pyVHDLModel
changes needed for either, since the model already fully supported both pieces of data.

### 1. Generate-statement alternative labels

If/elsif/else branches and case-generate alternatives always read their alternative label as an
empty string (`# TODO: alternative label` at 5 spots in `Concurrent.py`) - there was no way to
tell "no label given" apart from "label happens to be empty". Now reads
`Get_Alternative_Label(body)` properly, yielding `None` when no label was given.

**Caught a real, independent, pre-existing bug while testing this**: when a case-generate
alternative was immediately followed by `others` with no other cases in between,
`GenerateCase.parse()` was called with the wrong node (the already-advanced `others` alternative
instead of the original case's node - a stray `alternative` where every other call site correctly
used the tracked `caseNode` variable). This corrupted that case's label, and would have corrupted
its declared items/statements the same way, since both are read from the same wrong node via
`Get_Associated_Block`. Fixed the one-line typo.

### 2. Bit-string literal signed/length metadata

`sx"F"`/`ux"F"`/`8x"F"` signed/unsigned/length metadata was computed correctly from the IIR node
but never forwarded to the constructed literal object (`# TODO: add support for signed and
unsigned BitStringLiteral` / `# TODO: add support for BitStringLiteral lengths`) - purely a
forgot-to-pass-through bug, since pyVHDLModel's `BitStringLiteral` already fully supports both
fields.

Confirmed `16#FF#`-style based *integer* literals are unaffected - a completely different,
already-working literal kind (`Integer_Literal`, not `Bit_String_Literal`) where the base doesn't
affect the parsed value at all.

## Testing

Verified against real GHDL analysis (nightly libghdl build) for all cases: labeled/unlabeled if/
elsif/else branches, case-generate with a case immediately followed by others, and all four
bit-string signed/length combinations.

Added `testsuite/pyunit/dom/Generate.py` + `examples/GenerateLabels.vhdl`, and bit-string tests to
`testsuite/pyunit/dom/Literals.py`. Full suite: `56 passed` (was 49), 5 skipped, no regressions.
