### PR TITLE
Stop dropping subprogram declarations without a body

### DIFF
--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -860,10 +860,7 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                 yield ModeViewDeclaration.parse(item)
 
             elif kind == nodes.Iir_Kind.Function_Declaration:
-                if nodes.Get_Has_Body(item):
-                    yield Function.parse(item)
-                else:
-                    WarningCollector.Raise(NotImplementedError("function declaration without body"))
+                yield Function.parse(item)
 
                 lastKind = kind
                 item = nodes.Get_Chain(item)
@@ -885,10 +882,7 @@ def GetDeclaredItemsFromChainedNodes(nodeChain: Iir, entity: str, name: str) -> 
                         f"Found unexpected function body '{GetNameOfNode(item)}' in {entity} '{name}' at {position}."
                     )
             elif kind == nodes.Iir_Kind.Procedure_Declaration:
-                if nodes.Get_Has_Body(item):
-                    yield Procedure.parse(item)
-                else:
-                    WarningCollector.Raise(NotImplementedError("procedure declaration without body"))
+                yield Procedure.parse(item)
 
                 lastKind = kind
                 item = nodes.Get_Chain(item)

--- a/testsuite/pyunit/dom/Alias.py
+++ b/testsuite/pyunit/dom/Alias.py
@@ -97,7 +97,7 @@ class Aliases(TestCase):
         """``alias "+" is add[integer, integer return integer];`` - Name is extracted from the
         Signature node's prefix; the parameter/return type marks are not captured (documented FIXME)."""
         pkg = self._package()
-        alias = pkg.DeclaredItems[5]
+        alias = pkg.DeclaredItems[6]
 
         self.assertIsInstance(alias, Alias)
         self.assertIsNotNone(alias.Name)

--- a/testsuite/pyunit/dom/SubprogramsWithoutBodies.py
+++ b/testsuite/pyunit/dom/SubprogramsWithoutBodies.py
@@ -1,0 +1,107 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of subprogram declarations without a body.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Subprogram import Function, Procedure
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class SubprogramsWithoutBodies(TestCase):
+    """
+    Regression tests: a subprogram declaration without a body (e.g. a forward declaration in a
+    package spec whose body lives in a separate package body) was previously silently dropped
+    entirely from the declared items ('WarningCollector.Raise(NotImplementedError(...))', no yield
+    at all) - the declaration simply vanished from the model, even though it's perfectly valid,
+    common VHDL.
+
+    Function.parse()/Procedure.parse() already handled the no-body case gracefully on their own
+    (DeclaredItems/Statements come back empty, everything else populated correctly) - the fix was to
+    stop special-casing the has-no-body case in the dispatcher and just always call them.
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/SubprogramsWithoutBodies.vhdl"
+
+    @staticmethod
+    def _document():
+        design = Design()
+        document = Document(SubprogramsWithoutBodies._filename)
+        design.Documents.append(document)
+        return document
+
+    def test_FunctionDeclarationWithoutBody(self) -> None:
+        document = self._document()
+        pkg = document.Packages["subprogramswithoutbodies"]
+        function = pkg.DeclaredItems[0]
+
+        self.assertIsInstance(function, Function)
+        self.assertEqual("foo", function.Identifier)
+        self.assertIsNotNone(function.ReturnType)
+        self.assertEqual(0, len(function.DeclaredItems))
+        self.assertEqual(0, len(function.Statements))
+
+    def test_ProcedureDeclarationWithoutBody(self) -> None:
+        document = self._document()
+        pkg = document.Packages["subprogramswithoutbodies"]
+        procedure = pkg.DeclaredItems[1]
+
+        self.assertIsInstance(procedure, Procedure)
+        self.assertEqual("bar", procedure.Identifier)
+        self.assertEqual(0, len(procedure.DeclaredItems))
+        self.assertEqual(0, len(procedure.Statements))
+
+    def test_FunctionWithBodyStillWorks(self) -> None:
+        """Confirms the with-body case in the package body still works correctly (no regression,
+        no double-yielding via the separate Function_Body chain item)."""
+        document = self._document()
+        pkgBody = document.PackageBodies["subprogramswithoutbodies"]
+        function = pkgBody.DeclaredItems[0]
+
+        self.assertIsInstance(function, Function)
+        self.assertEqual("foo", function.Identifier)
+        self.assertEqual(1, len(function.Statements))
+
+    def test_ProcedureWithBodyStillWorks(self) -> None:
+        document = self._document()
+        pkgBody = document.PackageBodies["subprogramswithoutbodies"]
+        procedure = pkgBody.DeclaredItems[1]
+
+        self.assertIsInstance(procedure, Procedure)
+        self.assertEqual("bar", procedure.Identifier)

--- a/testsuite/pyunit/dom/examples/SubprogramsWithoutBodies.vhdl
+++ b/testsuite/pyunit/dom/examples/SubprogramsWithoutBodies.vhdl
@@ -1,0 +1,19 @@
+-- Author: Patrick Lehmann
+--
+-- Subprogram declarations without a body (forward declarations, e.g. a package spec whose body
+-- lives in a separate package body design unit) were previously silently dropped entirely.
+package SubprogramsWithoutBodies is
+	function foo(x : integer) return integer;
+	procedure bar(x : integer);
+end package SubprogramsWithoutBodies;
+
+package body SubprogramsWithoutBodies is
+	function foo(x : integer) return integer is
+	begin
+		return x + 1;
+	end function;
+
+	procedure bar(x : integer) is
+	begin
+	end procedure;
+end package body SubprogramsWithoutBodies;


### PR DESCRIPTION
## Summary

A subprogram declaration without a body (e.g. a forward declaration in a package spec whose body
lives in a separate package body design unit) was previously silently dropped entirely from the
declared items (`WarningCollector.Raise(NotImplementedError(...))`, no yield at all) - the
declaration simply vanished from the model, even though it's perfectly valid, common VHDL.

## Fix

`Function.parse()`/`Procedure.parse()` already handled the no-body case gracefully on their own -
`DeclaredItems`/`Statements` come back empty via their existing
`Get_Subprogram_Body(functionNode) != Null_Iir` guard, everything else (identifier, return type,
generics, parameters) populated correctly. Verified this directly before touching the dispatcher.
The actual fix was to stop special-casing the has-no-body case there and just always call
`Function.parse()`/`Procedure.parse()`.

**Note**: this doesn't yet distinguish "no body at all" from "body is empty" at the model level
(both produce `DeclaredItems=[]`/`Statements=[]`) - pyVHDLModel has no `HasBody`-style field for
that. Scoped this fix to the actual bug (stop losing the declaration entirely); a `HasBody` flag
would be a natural, separate follow-up if useful.

Updated `testsuite/pyunit/dom/Alias.py`: the forward-declared `function add` in `Aliases.vhdl` was
previously dropped, shifting the operator-alias test's index from 5 to 6 - fixed.

## Testing

Added `testsuite/pyunit/dom/SubprogramsWithoutBodies.py` + `examples/SubprogramsWithoutBodies.vhdl`,
covering both the previously-dropped no-body case and confirming the with-body case (package body)
still works correctly, with no double-yielding via the separate `Function_Body` chain item.

Verified against real GHDL analysis (nightly libghdl build). Full suite: `53 passed` (was 49), 5
skipped, no regressions.
