### PR TITLE
Translate conditional/selected/force/release assignment statements

### DIFF
--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -30,7 +30,7 @@
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 # ============================================================================
-from typing import Iterable, Optional as Nullable
+from typing import Iterable, List, Optional as Nullable
 
 from pyTooling.Decorators import export
 
@@ -645,6 +645,13 @@ class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
         return cls(waveNode, value, time)
 
 
+def GetWaveformElementsFromChainedNodes(nodeChain: Iir) -> List[WaveformElement]:
+    """Translates a chain of ``Waveform_Element`` nodes (used at multiple call sites: simple/
+    conditional/selected signal assignments, both concurrent and sequential) into a list of
+    :class:`WaveformElement`."""
+    return [WaveformElement.parse(wave) for wave in utils.chain_iter(nodeChain)]
+
+
 @export
 class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
     def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
@@ -653,12 +660,10 @@ class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "ConditionalWaveform":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
-        waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Waveform_Chain(node))]
-
-        conditionNode = nodes.Get_Condition(node)
-        condition = None if conditionNode == nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(node))
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
 
         return cls(node, waveform, condition)
 
@@ -720,11 +725,11 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
                 continue
         elif kind == nodes.Iir_Kind.Choice_By_Others:
             if choices is not None:
-                waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+                waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Associated_Chain(ownerNode))
                 alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
                 choices = None
 
-            othersWaveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(choice))]
+            othersWaveform = GetWaveformElementsFromChainedNodes(nodes.Get_Associated_Chain(choice))
             alternatives.append(OthersSelectedWaveform(choice, othersWaveform))
             choice = nodes.Get_Chain(choice)
             continue
@@ -733,7 +738,7 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
             raise DOMException(f"Unknown choice kind '{kind.name}' in selected waveform at {position}.")
 
         if choices is not None:
-            waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+            waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Associated_Chain(ownerNode))
             alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
 
         ownerNode = choice
@@ -741,7 +746,7 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
         choice = nodes.Get_Chain(choice)
 
     if choices is not None:
-        waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Associated_Chain(ownerNode))
         alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
 
     return alternatives
@@ -766,9 +771,7 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
         targetNode = nodes.Get_Target(assignmentNode)
         targetName = SignalSymbol(targetNode, GetName(targetNode))
 
-        waveform = []
-        for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
-            waveform.append(WaveformElement.parse(wave))
+        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(assignmentNode))
 
         return cls(assignmentNode, label, targetName, waveform)
 
@@ -861,14 +864,12 @@ class ConcurrentAssertStatement(VHDLModel_ConcurrentAssertStatement, DOMMixin):
 
     @classmethod
     def parse(cls, assertNode: Iir, label: str) -> "ConcurrentAssertStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         # FIXME: how to get the condition?
         # assertNode is a Psl_Assert_Directive
-        condition = None  # GetExpressionFromNode(nodes.Get_Assertion_Condition(assertNode))
-        messageNode = nodes.Get_Report_Expression(assertNode)
-        message = None if messageNode is nodes.Null_Iir else GetExpressionFromNode(messageNode)
-        severityNode = nodes.Get_Severity_Expression(assertNode)
-        severity = None if severityNode is nodes.Null_Iir else GetExpressionFromNode(severityNode)
+        condition = None  # GetOptionalExpressionFromNode(nodes.Get_Assertion_Condition(assertNode))
+        message = GetOptionalExpressionFromNode(nodes.Get_Report_Expression(assertNode))
+        severity = GetOptionalExpressionFromNode(nodes.Get_Severity_Expression(assertNode))
 
         return cls(assertNode, condition, message, severity, label)

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -83,6 +83,7 @@ from pyGHDL.dom.Symbol import (
     EntityInstantiationSymbol,
     ComponentInstantiationSymbol,
     ConfigurationInstantiationSymbol,
+    SignalSymbol,
 )
 
 
@@ -752,7 +753,7 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
         self,
         assignmentNode: Iir,
         label: str,
-        target: Symbol,
+        target: SignalSymbol,
         waveform: Iterable[WaveformElement],
     ) -> None:
         super().__init__(label, target, waveform)
@@ -762,8 +763,8 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSimpleSignalAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        target = nodes.Get_Target(assignmentNode)
-        targetName = GetName(target)
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
 
         waveform = []
         for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
@@ -778,7 +779,7 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
         self,
         assignmentNode: Iir,
         label: str,
-        target: Symbol,
+        target: SignalSymbol,
         conditionalWaveforms: Iterable[ConditionalWaveform],
     ) -> None:
         super().__init__(label, target, conditionalWaveforms)
@@ -788,7 +789,8 @@ class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSigna
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentConditionalSignalAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
         conditionalWaveforms = GetConditionalWaveformsFromChainedNodes(nodes.Get_Conditional_Waveform_Chain(assignmentNode))
 
         return cls(assignmentNode, label, targetName, conditionalWaveforms)
@@ -800,7 +802,7 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
         self,
         assignmentNode: Iir,
         label: str,
-        target: Symbol,
+        target: SignalSymbol,
         expression: ExpressionUnion,
         selectedWaveforms: Iterable,
     ) -> None:
@@ -811,7 +813,8 @@ class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssig
     def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSelectedSignalAssignment":
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
         expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
         selectedWaveforms = GetSelectedWaveformsFromChainedNodes(nodes.Get_Selected_Waveform_Chain(assignmentNode))
 

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -652,40 +652,10 @@ def GetWaveformElementsFromChainedNodes(nodeChain: Iir) -> List[WaveformElement]
     return [WaveformElement.parse(wave) for wave in utils.chain_iter(nodeChain)]
 
 
-@export
-class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
-    def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
-        super().__init__(waveform, condition)
-        DOMMixin.__init__(self, node)
-
-    @classmethod
-    def parse(cls, node: Iir) -> "ConditionalWaveform":
-        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
-
-        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(node))
-        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
-
-        return cls(node, waveform, condition)
-
-
-def GetConditionalWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable[ConditionalWaveform]:
+def GetConditionalWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable["ConditionalWaveform"]:
     """Translates a chain of ``Conditional_Waveform`` nodes (shared by concurrent and sequential
     conditional signal assignments) into a sequence of :class:`ConditionalWaveform`."""
     return [ConditionalWaveform.parse(node) for node in utils.chain_iter(nodeChain)]
-
-
-@export
-class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
-    def __init__(self, node: Iir, choices: Iterable, waveform: Iterable[WaveformElement]) -> None:
-        super().__init__(choices, waveform)
-        DOMMixin.__init__(self, node)
-
-
-@export
-class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
-    def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
-        super().__init__(waveform)
-        DOMMixin.__init__(self, node)
 
 
 def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
@@ -750,6 +720,36 @@ def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
         alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
 
     return alternatives
+
+
+@export
+class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
+    def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
+        super().__init__(waveform, condition)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "ConditionalWaveform":
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
+
+        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(node))
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
+
+        return cls(node, waveform, condition)
+
+
+@export
+class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
+    def __init__(self, node: Iir, choices: Iterable, waveform: Iterable[WaveformElement]) -> None:
+        super().__init__(choices, waveform)
+        DOMMixin.__init__(self, node)
+
+
+@export
+class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
+    def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
+        super().__init__(waveform)
+        DOMMixin.__init__(self, node)
 
 
 @export

--- a/pyGHDL/dom/Concurrent.py
+++ b/pyGHDL/dom/Concurrent.py
@@ -35,6 +35,11 @@ from typing import Iterable, Optional as Nullable
 from pyTooling.Decorators import export
 
 from pyVHDLModel.Base import ExpressionUnion, WaveformElement as VHDLModel_WaveformElement, ModelEntity
+from pyVHDLModel.Common import (
+    ConditionalWaveform as VHDLModel_ConditionalWaveform,
+    SelectedWaveform as VHDLModel_SelectedWaveform,
+    OthersSelectedWaveform as VHDLModel_OthersSelectedWaveform,
+)
 from pyVHDLModel.Symbol import Symbol
 from pyVHDLModel.Association import (
     AssociationItem,
@@ -59,6 +64,8 @@ from pyVHDLModel.Concurrent import (
     CaseGenerateStatement as VHDLModel_CaseGenerateStatement,
     ForGenerateStatement as VHDLModel_ForGenerateStatement,
     ConcurrentSimpleSignalAssignment as VHDLModel_ConcurrentSimpleSignalAssignment,
+    ConcurrentConditionalSignalAssignment as VHDLModel_ConcurrentConditionalSignalAssignment,
+    ConcurrentSelectedSignalAssignment as VHDLModel_ConcurrentSelectedSignalAssignment,
     ConcurrentAssertStatement as VHDLModel_ConcurrentAssertStatement,
     ConcurrentStatement,
     GenerateCase as VHDLModel_GenerateCase,
@@ -638,6 +645,108 @@ class WaveformElement(VHDLModel_WaveformElement, DOMMixin):
 
 
 @export
+class ConditionalWaveform(VHDLModel_ConditionalWaveform, DOMMixin):
+    def __init__(self, node: Iir, waveform: Iterable[WaveformElement], condition: ExpressionUnion = None) -> None:
+        super().__init__(waveform, condition)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "ConditionalWaveform":
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Waveform_Chain(node))]
+
+        conditionNode = nodes.Get_Condition(node)
+        condition = None if conditionNode == nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+
+        return cls(node, waveform, condition)
+
+
+def GetConditionalWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable[ConditionalWaveform]:
+    """Translates a chain of ``Conditional_Waveform`` nodes (shared by concurrent and sequential
+    conditional signal assignments) into a sequence of :class:`ConditionalWaveform`."""
+    return [ConditionalWaveform.parse(node) for node in utils.chain_iter(nodeChain)]
+
+
+@export
+class SelectedWaveform(VHDLModel_SelectedWaveform, DOMMixin):
+    def __init__(self, node: Iir, choices: Iterable, waveform: Iterable[WaveformElement]) -> None:
+        super().__init__(choices, waveform)
+        DOMMixin.__init__(self, node)
+
+
+@export
+class OthersSelectedWaveform(VHDLModel_OthersSelectedWaveform, DOMMixin):
+    def __init__(self, node: Iir, waveform: Iterable[WaveformElement]) -> None:
+        super().__init__(waveform)
+        DOMMixin.__init__(self, node)
+
+
+def GetSelectedWaveformsFromChainedNodes(nodeChain: Iir) -> Iterable:
+    """
+    Translates a chain of choices (shared by concurrent and sequential selected signal assignments)
+    into a sequence of :class:`SelectedWaveform`/:class:`OthersSelectedWaveform`.
+
+    Mirrors the grouping algorithm already used for case-generate alternatives
+    (``Get_Same_Alternative_Flag`` groups e.g. ``when 0 | 1 =>`` into one alternative): the *first*
+    choice in a group owns the real content (``Get_Associated_Chain``, ``Same_Alternative_Flag=False``);
+    later choices in the same group (``Same_Alternative_Flag=True``) have a null associated chain and
+    are just additional choice values for that same, already-established alternative.
+    """
+    from pyGHDL.dom._Utils import GetIirKindOfNode
+    from pyGHDL.dom._Translate import GetExpressionFromNode, GetRangeFromNode
+    from pyGHDL.dom.Sequential import IndexedChoice, RangedChoice
+
+    alternatives = []
+    choices = None
+    ownerNode = None
+    choice = nodeChain
+    while choice != nodes.Null_Iir:
+        kind = GetIirKindOfNode(choice)
+        sameAlternative = nodes.Get_Same_Alternative_Flag(choice)
+
+        if kind == nodes.Iir_Kind.Choice_By_Expression:
+            choiceValue = IndexedChoice(choice, GetExpressionFromNode(nodes.Get_Choice_Expression(choice)))
+            if sameAlternative:
+                choices.append(choiceValue)
+                choice = nodes.Get_Chain(choice)
+                continue
+        elif kind == nodes.Iir_Kind.Choice_By_Range:
+            choiceValue = RangedChoice(choice, GetRangeFromNode(nodes.Get_Choice_Range(choice)))
+            if sameAlternative:
+                choices.append(choiceValue)
+                choice = nodes.Get_Chain(choice)
+                continue
+        elif kind == nodes.Iir_Kind.Choice_By_Others:
+            if choices is not None:
+                waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+                alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
+                choices = None
+
+            othersWaveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(choice))]
+            alternatives.append(OthersSelectedWaveform(choice, othersWaveform))
+            choice = nodes.Get_Chain(choice)
+            continue
+        else:
+            position = Position.parse(choice)
+            raise DOMException(f"Unknown choice kind '{kind.name}' in selected waveform at {position}.")
+
+        if choices is not None:
+            waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+            alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
+
+        ownerNode = choice
+        choices = [choiceValue]
+        choice = nodes.Get_Chain(choice)
+
+    if choices is not None:
+        waveform = [WaveformElement.parse(wave) for wave in utils.chain_iter(nodes.Get_Associated_Chain(ownerNode))]
+        alternatives.append(SelectedWaveform(ownerNode, choices, waveform))
+
+    return alternatives
+
+
+@export
 class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignment, DOMMixin):
     def __init__(
         self,
@@ -661,6 +770,52 @@ class ConcurrentSimpleSignalAssignment(VHDLModel_ConcurrentSimpleSignalAssignmen
             waveform.append(WaveformElement.parse(wave))
 
         return cls(assignmentNode, label, targetName, waveform)
+
+
+@export
+class ConcurrentConditionalSignalAssignment(VHDLModel_ConcurrentConditionalSignalAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        label: str,
+        target: Symbol,
+        conditionalWaveforms: Iterable[ConditionalWaveform],
+    ) -> None:
+        super().__init__(label, target, conditionalWaveforms)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentConditionalSignalAssignment":
+        from pyGHDL.dom._Translate import GetName
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        conditionalWaveforms = GetConditionalWaveformsFromChainedNodes(nodes.Get_Conditional_Waveform_Chain(assignmentNode))
+
+        return cls(assignmentNode, label, targetName, conditionalWaveforms)
+
+
+@export
+class ConcurrentSelectedSignalAssignment(VHDLModel_ConcurrentSelectedSignalAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        label: str,
+        target: Symbol,
+        expression: ExpressionUnion,
+        selectedWaveforms: Iterable,
+    ) -> None:
+        super().__init__(label, target, expression, selectedWaveforms)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str) -> "ConcurrentSelectedSignalAssignment":
+        from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
+        selectedWaveforms = GetSelectedWaveformsFromChainedNodes(nodes.Get_Selected_Waveform_Chain(assignmentNode))
+
+        return cls(assignmentNode, label, targetName, expression, selectedWaveforms)
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -73,6 +73,7 @@ from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom.Range import Range
 from pyGHDL.dom.Concurrent import WaveformElement, ParameterAssociationItem  # TODO: move out from concurrent?
+from pyGHDL.dom.Concurrent import GetWaveformElementsFromChainedNodes
 from pyGHDL.dom.Symbol import SignalSymbol, VariableSymbol
 from pyGHDL.dom.Concurrent import GetConditionalWaveformsFromChainedNodes, GetSelectedWaveformsFromChainedNodes
 
@@ -400,7 +401,7 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
             GetSequentialStatementsFromChainedNodes,
             GetRangeFromNode,
             GetName,
-            GetExpressionFromNode,
+            GetOptionalExpressionFromNode,
         )
 
         # spec = nodes.Get_Parameter_Specification(loopNode)
@@ -421,8 +422,7 @@ class WhileLoopStatement(VHDLModel_WhileLoopStatement, DOMMixin):
         #         f"Unknown discrete range kind '{rangeKind.name}' in for...loop statement at line {pos.Line}."
         #     )
 
-        conditionNode = nodes.Get_Condition(loopNode)
-        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(loopNode))
 
         statementChain = nodes.Get_Sequential_Statement_Chain(loopNode)
         statements = GetSequentialStatementsFromChainedNodes(statementChain, "while", label)
@@ -449,9 +449,7 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
         targetNode = nodes.Get_Target(assignmentNode)
         targetName = SignalSymbol(targetNode, GetName(targetNode))
 
-        waveform = []
-        for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
-            waveform.append(WaveformElement.parse(wave))
+        waveform = GetWaveformElementsFromChainedNodes(nodes.Get_Waveform_Chain(assignmentNode))
 
         return cls(assignmentNode, targetName, waveform, label)
 
@@ -464,12 +462,10 @@ class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
 
     @classmethod
     def parse(cls, node: Iir) -> "ConditionalExpression":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         expression = GetExpressionFromNode(nodes.Get_Expression(node))
-
-        conditionNode = nodes.Get_Condition(node)
-        condition = None if conditionNode == nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
 
         return cls(node, expression, condition)
 
@@ -756,13 +752,11 @@ class SequentialAssertStatement(VHDLModel_SequentialAssertStatement, DOMMixin):
 
     @classmethod
     def parse(cls, assertNode: Iir, label: str) -> "SequentialAssertStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         condition = GetExpressionFromNode(nodes.Get_Assertion_Condition(assertNode))
-        messageNode = nodes.Get_Report_Expression(assertNode)
-        message = None if messageNode is nodes.Null_Iir else GetExpressionFromNode(messageNode)
-        severityNode = nodes.Get_Severity_Expression(assertNode)
-        severity = None if severityNode is nodes.Null_Iir else GetExpressionFromNode(severityNode)
+        message = GetOptionalExpressionFromNode(nodes.Get_Report_Expression(assertNode))
+        severity = GetOptionalExpressionFromNode(nodes.Get_Severity_Expression(assertNode))
 
         return cls(assertNode, condition, message, severity, label)
 
@@ -781,11 +775,10 @@ class SequentialReportStatement(VHDLModel_SequentialReportStatement, DOMMixin):
 
     @classmethod
     def parse(cls, reportNode: Iir, label: str) -> "SequentialReportStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
 
         message = GetExpressionFromNode(nodes.Get_Report_Expression(reportNode))
-        severityNode = nodes.Get_Severity_Expression(reportNode)
-        severity = None if severityNode is nodes.Null_Iir else GetExpressionFromNode(severityNode)
+        severity = GetOptionalExpressionFromNode(nodes.Get_Severity_Expression(reportNode))
 
         return cls(reportNode, message, severity, label)
 
@@ -803,10 +796,9 @@ class ReturnStatement(VHDLModel_ReturnStatement, DOMMixin):
 
     @classmethod
     def parse(cls, returnNode: Iir, label: str) -> "ReturnStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
-        returnValueNode = nodes.Get_Expression(returnNode)
-        returnValue = None if returnValueNode is nodes.Null_Iir else GetExpressionFromNode(returnValueNode)
+        returnValue = GetOptionalExpressionFromNode(nodes.Get_Expression(returnNode))
 
         return cls(returnNode, returnValue, label)
 
@@ -835,10 +827,9 @@ class NextStatement(VHDLModel_NextStatement, DOMMixin):
 
     @classmethod
     def parse(cls, exitNode: Iir, label: str) -> "NextStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
-        conditionNode = nodes.Get_Condition(exitNode)
-        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(exitNode))
 
         return cls(exitNode, condition, label)
 
@@ -856,10 +847,9 @@ class ExitStatement(VHDLModel_ExitStatement, DOMMixin):
 
     @classmethod
     def parse(cls, exitNode: Iir, label: str) -> "ExitStatement":
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
-        conditionNode = nodes.Get_Condition(exitNode)
-        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(exitNode))
 
         return cls(exitNode, condition, label)
 
@@ -880,7 +870,7 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
     @classmethod
     def parse(cls, waitNode: Iir, label: str) -> "WaitStatement":
         from pyGHDL.dom._Utils import GetIirKindOfNode
-        from pyGHDL.dom._Translate import GetExpressionFromNode
+        from pyGHDL.dom._Translate import GetOptionalExpressionFromNode
 
         sensitivityList = None
         sensitivityListNode = nodes.Get_Sensitivity_List(waitNode)
@@ -888,10 +878,8 @@ class WaitStatement(VHDLModel_WaitStatement, DOMMixin):
             pass
             # print(f"WaitStatement: wait on {GetIirKindOfNode(sensitivityListNode)}")
 
-        conditionNode = nodes.Get_Condition_Clause(waitNode)
-        condition = None if conditionNode is nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition_Clause(waitNode))
 
-        timeoutNode = nodes.Get_Timeout_Clause(waitNode)
-        timeout = None if timeoutNode is nodes.Null_Iir else GetExpressionFromNode(timeoutNode)
+        timeout = GetOptionalExpressionFromNode(nodes.Get_Timeout_Clause(waitNode))
 
         return cls(waitNode, sensitivityList, condition, timeout, label)

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -454,39 +454,9 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
         return cls(assignmentNode, targetName, waveform, label)
 
 
-@export
-class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
-    def __init__(self, node: Iir, expression: ExpressionUnion, condition: ExpressionUnion = None) -> None:
-        super().__init__(expression, condition)
-        DOMMixin.__init__(self, node)
-
-    @classmethod
-    def parse(cls, node: Iir) -> "ConditionalExpression":
-        from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
-
-        expression = GetExpressionFromNode(nodes.Get_Expression(node))
-        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
-
-        return cls(node, expression, condition)
-
-
-def GetConditionalExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable[ConditionalExpression]:
+def GetConditionalExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable["ConditionalExpression"]:
     """Translates a chain of ``Conditional_Expression`` nodes into a sequence of :class:`ConditionalExpression`."""
     return [ConditionalExpression.parse(node) for node in utils.chain_iter(nodeChain)]
-
-
-@export
-class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
-    def __init__(self, node: Iir, choices: Iterable, expression: ExpressionUnion) -> None:
-        super().__init__(choices, expression)
-        DOMMixin.__init__(self, node)
-
-
-@export
-class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
-    def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
-        super().__init__(expression)
-        DOMMixin.__init__(self, node)
 
 
 def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
@@ -546,6 +516,36 @@ def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
         alternatives.append(SelectedExpression(ownerNode, choices, expression))
 
     return alternatives
+
+
+@export
+class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
+    def __init__(self, node: Iir, expression: ExpressionUnion, condition: ExpressionUnion = None) -> None:
+        super().__init__(expression, condition)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "ConditionalExpression":
+        from pyGHDL.dom._Translate import GetExpressionFromNode, GetOptionalExpressionFromNode
+
+        expression = GetExpressionFromNode(nodes.Get_Expression(node))
+        condition = GetOptionalExpressionFromNode(nodes.Get_Condition(node))
+
+        return cls(node, expression, condition)
+
+
+@export
+class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
+    def __init__(self, node: Iir, choices: Iterable, expression: ExpressionUnion) -> None:
+        super().__init__(choices, expression)
+        DOMMixin.__init__(self, node)
+
+
+@export
+class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
+    def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        super().__init__(expression)
+        DOMMixin.__init__(self, node)
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -55,6 +55,16 @@ from pyVHDLModel.Sequential import NextStatement as VHDLModel_NextStatement
 from pyVHDLModel.Sequential import ExitStatement as VHDLModel_ExitStatement
 from pyVHDLModel.Sequential import SequentialProcedureCall as VHDLModel_SequentialProcedureCall
 from pyVHDLModel.Sequential import SequentialSimpleSignalAssignment as VHDLModel_SequentialSimpleSignalAssignment
+from pyVHDLModel.Sequential import SequentialVariableAssignment as VHDLModel_SequentialVariableAssignment
+from pyVHDLModel.Sequential import SequentialConditionalVariableAssignment as VHDLModel_SequentialConditionalVariableAssignment
+from pyVHDLModel.Sequential import SequentialConditionalSignalAssignment as VHDLModel_SequentialConditionalSignalAssignment
+from pyVHDLModel.Sequential import SequentialSelectedVariableAssignment as VHDLModel_SequentialSelectedVariableAssignment
+from pyVHDLModel.Sequential import SequentialSelectedSignalAssignment as VHDLModel_SequentialSelectedSignalAssignment
+from pyVHDLModel.Sequential import SignalForceAssignment as VHDLModel_SignalForceAssignment
+from pyVHDLModel.Sequential import SignalReleaseAssignment as VHDLModel_SignalReleaseAssignment
+from pyVHDLModel.Common import ConditionalExpression as VHDLModel_ConditionalExpression
+from pyVHDLModel.Common import SelectedExpression as VHDLModel_SelectedExpression
+from pyVHDLModel.Common import OthersSelectedExpression as VHDLModel_OthersSelectedExpression
 from pyVHDLModel.Sequential import SequentialReportStatement as VHDLModel_SequentialReportStatement
 from pyVHDLModel.Sequential import SequentialAssertStatement as VHDLModel_SequentialAssertStatement
 
@@ -63,6 +73,7 @@ from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom.Range import Range
 from pyGHDL.dom.Concurrent import WaveformElement, ParameterAssociationItem  # TODO: move out from concurrent?
+from pyGHDL.dom.Concurrent import GetConditionalWaveformsFromChainedNodes, GetSelectedWaveformsFromChainedNodes
 
 
 @export
@@ -442,6 +453,259 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
             waveform.append(WaveformElement.parse(wave))
 
         return cls(assignmentNode, targetName, waveform, label)
+
+
+@export
+class ConditionalExpression(VHDLModel_ConditionalExpression, DOMMixin):
+    def __init__(self, node: Iir, expression: ExpressionUnion, condition: ExpressionUnion = None) -> None:
+        super().__init__(expression, condition)
+        DOMMixin.__init__(self, node)
+
+    @classmethod
+    def parse(cls, node: Iir) -> "ConditionalExpression":
+        from pyGHDL.dom._Translate import GetExpressionFromNode
+
+        expression = GetExpressionFromNode(nodes.Get_Expression(node))
+
+        conditionNode = nodes.Get_Condition(node)
+        condition = None if conditionNode == nodes.Null_Iir else GetExpressionFromNode(conditionNode)
+
+        return cls(node, expression, condition)
+
+
+def GetConditionalExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable[ConditionalExpression]:
+    """Translates a chain of ``Conditional_Expression`` nodes into a sequence of :class:`ConditionalExpression`."""
+    return [ConditionalExpression.parse(node) for node in utils.chain_iter(nodeChain)]
+
+
+@export
+class SelectedExpression(VHDLModel_SelectedExpression, DOMMixin):
+    def __init__(self, node: Iir, choices: Iterable, expression: ExpressionUnion) -> None:
+        super().__init__(choices, expression)
+        DOMMixin.__init__(self, node)
+
+
+@export
+class OthersSelectedExpression(VHDLModel_OthersSelectedExpression, DOMMixin):
+    def __init__(self, node: Iir, expression: ExpressionUnion) -> None:
+        super().__init__(expression)
+        DOMMixin.__init__(self, node)
+
+
+def GetSelectedExpressionsFromChainedNodes(nodeChain: Iir) -> Iterable:
+    """
+    Translates a chain of choices into a sequence of :class:`SelectedExpression`/
+    :class:`OthersSelectedExpression`. Same grouping algorithm as
+    :func:`pyGHDL.dom.Concurrent.GetSelectedWaveformsFromChainedNodes`, but the associated content is
+    a plain expression (``Get_Associated_Expr``) instead of a waveform chain.
+    """
+    from pyGHDL.dom._Utils import GetIirKindOfNode
+    from pyGHDL.dom._Translate import GetExpressionFromNode, GetRangeFromNode
+
+    alternatives = []
+    choices = None
+    ownerNode = None
+    choice = nodeChain
+    while choice != nodes.Null_Iir:
+        kind = GetIirKindOfNode(choice)
+        sameAlternative = nodes.Get_Same_Alternative_Flag(choice)
+
+        if kind == nodes.Iir_Kind.Choice_By_Expression:
+            choiceValue = IndexedChoice(choice, GetExpressionFromNode(nodes.Get_Choice_Expression(choice)))
+            if sameAlternative:
+                choices.append(choiceValue)
+                choice = nodes.Get_Chain(choice)
+                continue
+        elif kind == nodes.Iir_Kind.Choice_By_Range:
+            choiceValue = RangedChoice(choice, GetRangeFromNode(nodes.Get_Choice_Range(choice)))
+            if sameAlternative:
+                choices.append(choiceValue)
+                choice = nodes.Get_Chain(choice)
+                continue
+        elif kind == nodes.Iir_Kind.Choice_By_Others:
+            if choices is not None:
+                expression = GetExpressionFromNode(nodes.Get_Associated_Expr(ownerNode))
+                alternatives.append(SelectedExpression(ownerNode, choices, expression))
+                choices = None
+
+            othersExpression = GetExpressionFromNode(nodes.Get_Associated_Expr(choice))
+            alternatives.append(OthersSelectedExpression(choice, othersExpression))
+            choice = nodes.Get_Chain(choice)
+            continue
+        else:
+            position = Position.parse(choice)
+            raise DOMException(f"Unknown choice kind '{kind.name}' in selected expression at {position}.")
+
+        if choices is not None:
+            expression = GetExpressionFromNode(nodes.Get_Associated_Expr(ownerNode))
+            alternatives.append(SelectedExpression(ownerNode, choices, expression))
+
+        ownerNode = choice
+        choices = [choiceValue]
+        choice = nodes.Get_Chain(choice)
+
+    if choices is not None:
+        expression = GetExpressionFromNode(nodes.Get_Associated_Expr(ownerNode))
+        alternatives.append(SelectedExpression(ownerNode, choices, expression))
+
+    return alternatives
+
+
+@export
+class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        expression: ExpressionUnion,
+        label: str = None,
+    ) -> None:
+        super().__init__(target, expression, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialVariableAssignment":
+        from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
+
+        return cls(assignmentNode, targetName, expression, label)
+
+
+@export
+class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVariableAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        conditionalExpressions: Iterable[ConditionalExpression],
+        label: str = None,
+    ) -> None:
+        super().__init__(target, conditionalExpressions, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalVariableAssignment":
+        from pyGHDL.dom._Translate import GetName
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        conditionalExpressions = GetConditionalExpressionsFromChainedNodes(
+            nodes.Get_Conditional_Expression_Chain(assignmentNode)
+        )
+
+        return cls(assignmentNode, targetName, conditionalExpressions, label)
+
+
+@export
+class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSignalAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        conditionalWaveforms: Iterable,
+        label: str = None,
+    ) -> None:
+        super().__init__(target, conditionalWaveforms, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalSignalAssignment":
+        from pyGHDL.dom._Translate import GetName
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        conditionalWaveforms = GetConditionalWaveformsFromChainedNodes(
+            nodes.Get_Conditional_Waveform_Chain(assignmentNode)
+        )
+
+        return cls(assignmentNode, targetName, conditionalWaveforms, label)
+
+
+@export
+class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        expression: ExpressionUnion,
+        selectedExpressions: Iterable,
+        label: str = None,
+    ) -> None:
+        super().__init__(target, expression, selectedExpressions, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedVariableAssignment":
+        from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
+        selectedExpressions = GetSelectedExpressionsFromChainedNodes(
+            nodes.Get_Selected_Expressions_Chain(assignmentNode)
+        )
+
+        return cls(assignmentNode, targetName, expression, selectedExpressions, label)
+
+
+@export
+class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        expression: ExpressionUnion,
+        selectedWaveforms: Iterable,
+        label: str = None,
+    ) -> None:
+        super().__init__(target, expression, selectedWaveforms, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedSignalAssignment":
+        from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
+        selectedWaveforms = GetSelectedWaveformsFromChainedNodes(nodes.Get_Selected_Waveform_Chain(assignmentNode))
+
+        return cls(assignmentNode, targetName, expression, selectedWaveforms, label)
+
+
+@export
+class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
+    def __init__(
+        self,
+        assignmentNode: Iir,
+        target: Symbol,
+        expression: ExpressionUnion,
+        label: str = None,
+    ) -> None:
+        super().__init__(target, expression, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalForceAssignment":
+        from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+        expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
+
+        return cls(assignmentNode, targetName, expression, label)
+
+
+@export
+class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
+    def __init__(self, assignmentNode: Iir, target: Symbol, label: str = None) -> None:
+        super().__init__(target, label)
+        DOMMixin.__init__(self, assignmentNode)
+
+    @classmethod
+    def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalReleaseAssignment":
+        from pyGHDL.dom._Translate import GetName
+
+        targetName = GetName(nodes.Get_Target(assignmentNode))
+
+        return cls(assignmentNode, targetName, label)
 
 
 @export

--- a/pyGHDL/dom/Sequential.py
+++ b/pyGHDL/dom/Sequential.py
@@ -73,6 +73,7 @@ from pyGHDL.libghdl.vhdl import nodes
 from pyGHDL.dom import DOMMixin, Position, DOMException
 from pyGHDL.dom.Range import Range
 from pyGHDL.dom.Concurrent import WaveformElement, ParameterAssociationItem  # TODO: move out from concurrent?
+from pyGHDL.dom.Symbol import SignalSymbol, VariableSymbol
 from pyGHDL.dom.Concurrent import GetConditionalWaveformsFromChainedNodes, GetSelectedWaveformsFromChainedNodes
 
 
@@ -434,7 +435,7 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: SignalSymbol,
         waveform: Iterable[WaveformElement],
         label: str = None,
     ) -> None:
@@ -445,8 +446,8 @@ class SequentialSimpleSignalAssignment(VHDLModel_SequentialSimpleSignalAssignmen
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSimpleSignalAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        target = nodes.Get_Target(assignmentNode)
-        targetName = GetName(target)
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
 
         waveform = []
         for wave in utils.chain_iter(nodes.Get_Waveform_Chain(assignmentNode)):
@@ -556,7 +557,7 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: VariableSymbol,
         expression: ExpressionUnion,
         label: str = None,
     ) -> None:
@@ -567,7 +568,8 @@ class SequentialVariableAssignment(VHDLModel_SequentialVariableAssignment, DOMMi
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialVariableAssignment":
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = VariableSymbol(targetNode, GetName(targetNode))
         expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
 
         return cls(assignmentNode, targetName, expression, label)
@@ -578,7 +580,7 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: VariableSymbol,
         conditionalExpressions: Iterable[ConditionalExpression],
         label: str = None,
     ) -> None:
@@ -589,7 +591,8 @@ class SequentialConditionalVariableAssignment(VHDLModel_SequentialConditionalVar
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalVariableAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = VariableSymbol(targetNode, GetName(targetNode))
         conditionalExpressions = GetConditionalExpressionsFromChainedNodes(
             nodes.Get_Conditional_Expression_Chain(assignmentNode)
         )
@@ -602,7 +605,7 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: SignalSymbol,
         conditionalWaveforms: Iterable,
         label: str = None,
     ) -> None:
@@ -613,7 +616,8 @@ class SequentialConditionalSignalAssignment(VHDLModel_SequentialConditionalSigna
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialConditionalSignalAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
         conditionalWaveforms = GetConditionalWaveformsFromChainedNodes(
             nodes.Get_Conditional_Waveform_Chain(assignmentNode)
         )
@@ -626,7 +630,7 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: VariableSymbol,
         expression: ExpressionUnion,
         selectedExpressions: Iterable,
         label: str = None,
@@ -638,7 +642,8 @@ class SequentialSelectedVariableAssignment(VHDLModel_SequentialSelectedVariableA
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedVariableAssignment":
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = VariableSymbol(targetNode, GetName(targetNode))
         expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
         selectedExpressions = GetSelectedExpressionsFromChainedNodes(
             nodes.Get_Selected_Expressions_Chain(assignmentNode)
@@ -652,7 +657,7 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: SignalSymbol,
         expression: ExpressionUnion,
         selectedWaveforms: Iterable,
         label: str = None,
@@ -664,7 +669,8 @@ class SequentialSelectedSignalAssignment(VHDLModel_SequentialSelectedSignalAssig
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SequentialSelectedSignalAssignment":
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
         expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
         selectedWaveforms = GetSelectedWaveformsFromChainedNodes(nodes.Get_Selected_Waveform_Chain(assignmentNode))
 
@@ -676,7 +682,7 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
     def __init__(
         self,
         assignmentNode: Iir,
-        target: Symbol,
+        target: SignalSymbol,
         expression: ExpressionUnion,
         label: str = None,
     ) -> None:
@@ -687,7 +693,8 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalForceAssignment":
         from pyGHDL.dom._Translate import GetName, GetExpressionFromNode
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
         expression = GetExpressionFromNode(nodes.Get_Expression(assignmentNode))
 
         return cls(assignmentNode, targetName, expression, label)
@@ -695,7 +702,7 @@ class SignalForceAssignment(VHDLModel_SignalForceAssignment, DOMMixin):
 
 @export
 class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
-    def __init__(self, assignmentNode: Iir, target: Symbol, label: str = None) -> None:
+    def __init__(self, assignmentNode: Iir, target: SignalSymbol, label: str = None) -> None:
         super().__init__(target, label)
         DOMMixin.__init__(self, assignmentNode)
 
@@ -703,7 +710,8 @@ class SignalReleaseAssignment(VHDLModel_SignalReleaseAssignment, DOMMixin):
     def parse(cls, assignmentNode: Iir, label: str = None) -> "SignalReleaseAssignment":
         from pyGHDL.dom._Translate import GetName
 
-        targetName = GetName(nodes.Get_Target(assignmentNode))
+        targetNode = nodes.Get_Target(assignmentNode)
+        targetName = SignalSymbol(targetNode, GetName(targetNode))
 
         return cls(assignmentNode, targetName, label)
 

--- a/pyGHDL/dom/Symbol.py
+++ b/pyGHDL/dom/Symbol.py
@@ -47,6 +47,8 @@ from pyVHDLModel.Symbol import PackageReferenceSymbol as VHDLModel_PackageRefere
 from pyVHDLModel.Symbol import ModeViewSymbol as VHDLModel_ModeViewSymbol
 from pyVHDLModel.Symbol import SubprogramReferenceSymbol as VHDLModel_SubprogramReferenceSymbol
 from pyVHDLModel.Symbol import ConfigurationSymbol as VHDLModel_ConfigurationSymbol
+from pyVHDLModel.Symbol import SignalSymbol as VHDLModel_SignalSymbol
+from pyVHDLModel.Symbol import VariableSymbol as VHDLModel_VariableSymbol
 from pyVHDLModel.Symbol import PackageMemberReferenceSymbol as VHDLModel_PackageMemberReferenceSymbol
 from pyVHDLModel.Symbol import AllPackageMembersReferenceSymbol as VHDLModel_AllPackageMembersReferenceSymbol
 from pyVHDLModel.Symbol import ContextReferenceSymbol as VHDLModel_ContextReferenceSymbol
@@ -188,6 +190,48 @@ class ConfigurationSymbol(VHDLModel_ConfigurationSymbol, DOMMixin):
     """
 
     @InheritDocString(VHDLModel_ConfigurationSymbol)
+    def __init__(self, identifierNode: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class SignalSymbol(VHDLModel_SignalSymbol, DOMMixin):
+    """
+    Represents a reference (name) to a signal, e.g. the target of a signal assignment.
+
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.SignalSymbol`.
+
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          s <= '1';
+          --^
+    """
+
+    @InheritDocString(VHDLModel_SignalSymbol)
+    def __init__(self, identifierNode: Iir, name: Name) -> None:
+        super().__init__(name)
+        DOMMixin.__init__(self, identifierNode)
+
+
+@export
+class VariableSymbol(VHDLModel_VariableSymbol, DOMMixin):
+    """
+    Represents a reference (name) to a variable, e.g. the target of a variable assignment.
+
+    This class implements a :mod:`pyGHDL.dom` object derived from :class:`pyVHDLModel.Symbol.VariableSymbol`.
+
+    .. admonition:: Example
+
+       .. code-block:: VHDL
+
+          v := '1';
+          --^
+    """
+
+    @InheritDocString(VHDLModel_VariableSymbol)
     def __init__(self, identifierNode: Iir, name: Name) -> None:
         super().__init__(name)
         DOMMixin.__init__(self, identifierNode)

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -34,7 +34,7 @@
 This module offers helper functions to translate often used IIR substructures to pyGHDL.dom (pyVHDLModel) constructs.
 """
 
-from typing import List, Generator, Type, Dict
+from typing import List, Generator, Type, Dict, Optional as Nullable
 
 from pyTooling.Decorators import export
 from pyTooling.Warning import WarningCollector
@@ -547,6 +547,19 @@ def GetExpressionFromNode(node: Iir) -> ExpressionUnion:
         raise DOMException(f"Unknown expression kind '{kind.name}' in expression '{node}' at {position}.")
 
     return cls.parse(node)
+
+
+def GetOptionalExpressionFromNode(node: Iir) -> Nullable[ExpressionUnion]:
+    """
+    Like :func:`GetExpressionFromNode`, but for fields that may legitimately be absent (e.g. an
+    optional condition on the final branch of a conditional assignment, or on an unconditional
+    ``exit``/``next`` statement) - returns ``None`` instead of translating when ``node`` is
+    ``Null_Iir``, rather than requiring every call site to repeat that check.
+
+    :param node: The IIR node representing an expression, or ``Null_Iir`` if absent.
+    :return:     The translated expression, or ``None``.
+    """
+    return None if node == nodes.Null_Iir else GetExpressionFromNode(node)
 
 
 @export

--- a/pyGHDL/dom/_Translate.py
+++ b/pyGHDL/dom/_Translate.py
@@ -1000,17 +1000,13 @@ def GetConcurrentStatementsFromChainedNodes(
         elif kind == nodes.Iir_Kind.Concurrent_Simple_Signal_Assignment:
             yield ConcurrentSimpleSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Conditional_Signal_Assignment:
-            WarningCollector.Raise(
-                NotImplementedError(
-                    f"Concurrent (conditional) signal assignment (label: '{label}') at line {position.Line}"
-                )
-            )
+            from pyGHDL.dom.Concurrent import ConcurrentConditionalSignalAssignment
+
+            yield ConcurrentConditionalSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Selected_Signal_Assignment:
-            WarningCollector.Raise(
-                NotImplementedError(
-                    f"Concurrent (selected) signal assignment (label: '{label}') at line {position.Line}"
-                )
-            )
+            from pyGHDL.dom.Concurrent import ConcurrentSelectedSignalAssignment
+
+            yield ConcurrentSelectedSignalAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Concurrent_Procedure_Call_Statement:
             yield ConcurrentProcedureCall.parse(statement, label)
         elif kind == nodes.Iir_Kind.Component_Instantiation_Statement:
@@ -1069,14 +1065,34 @@ def GetSequentialStatementsFromChainedNodes(
             yield WhileLoopStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Simple_Signal_Assignment_Statement:
             yield SequentialSimpleSignalAssignment.parse(statement, label)
-        elif kind in (
-            nodes.Iir_Kind.Variable_Assignment_Statement,
-            nodes.Iir_Kind.Conditional_Variable_Assignment_Statement,
-            nodes.Iir_Kind.Conditional_Signal_Assignment_Statement,
-        ):
-            WarningCollector.Raise(
-                NotImplementedError(f"Variable assignment (label: '{label}') at line {position.Line}")
-            )
+        elif kind == nodes.Iir_Kind.Variable_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SequentialVariableAssignment
+
+            yield SequentialVariableAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Conditional_Variable_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SequentialConditionalVariableAssignment
+
+            yield SequentialConditionalVariableAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Conditional_Signal_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SequentialConditionalSignalAssignment
+
+            yield SequentialConditionalSignalAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Selected_Variable_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SequentialSelectedVariableAssignment
+
+            yield SequentialSelectedVariableAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Selected_Waveform_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SequentialSelectedSignalAssignment
+
+            yield SequentialSelectedSignalAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Signal_Force_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SignalForceAssignment
+
+            yield SignalForceAssignment.parse(statement, label)
+        elif kind == nodes.Iir_Kind.Signal_Release_Assignment_Statement:
+            from pyGHDL.dom.Sequential import SignalReleaseAssignment
+
+            yield SignalReleaseAssignment.parse(statement, label)
         elif kind == nodes.Iir_Kind.Wait_Statement:
             yield WaitStatement.parse(statement, label)
         elif kind == nodes.Iir_Kind.Procedure_Call_Statement:

--- a/testsuite/pyunit/dom/Assignments.py
+++ b/testsuite/pyunit/dom/Assignments.py
@@ -1,0 +1,153 @@
+# =============================================================================
+#               ____ _   _ ____  _          _
+#  _ __  _   _ / ___| | | |  _ \| |      __| | ___  _ __ ___
+# | '_ \| | | | |  _| |_| | | | | |     / _` |/ _ \| '_ ` _ \
+# | |_) | |_| | |_| |  _  | |_| | |___ | (_| | (_) | | | | | |
+# | .__/ \__, |\____|_| |_|____/|_____(_)__,_|\___/|_| |_| |_|
+# |_|    |___/
+# =============================================================================
+# Authors:
+#   Patrick Lehmann
+#
+# Testsuite:        Check libghdl IIR translation of conditional/selected/force/release assignments.
+#
+# License:
+# ============================================================================
+#  Copyright (C) 2019-2026 Tristan Gingold
+#
+#  This program is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <gnu.org/licenses>.
+#
+# SPDX-License-Identifier: GPL-2.0-or-later
+# ============================================================================
+from pathlib import Path
+from unittest import TestCase
+
+from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Concurrent import ConcurrentConditionalSignalAssignment, ConcurrentSelectedSignalAssignment
+from pyGHDL.dom.Concurrent import SelectedWaveform, OthersSelectedWaveform
+from pyGHDL.dom.Sequential import (
+    SequentialVariableAssignment,
+    SequentialConditionalVariableAssignment, SequentialConditionalSignalAssignment,
+    SequentialSelectedVariableAssignment, SequentialSelectedSignalAssignment,
+    SelectedExpression, OthersSelectedExpression,
+    SignalForceAssignment, SignalReleaseAssignment,
+)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print("ERROR: you called a testcase declaration file as an executable module.")
+    print("Use: 'python -m unitest <testcase module>'")
+    exit(1)
+
+
+class Assignments(TestCase):
+    """
+    Regression tests: conditional/selected/force/release assignment statements were previously the
+    only gap remaining in both the concurrent and sequential statement dispatchers - either warn-only
+    (silently dropped) or a hard crash ('Unknown ... statement kind').
+    """
+
+    _root = Path(__file__).resolve().parent
+    _filename: Path = _root / "examples/Assignments.vhdl"
+
+    @staticmethod
+    def _architecture():
+        design = Design()
+        document = Document(Assignments._filename)
+        design.Documents.append(document)
+        return document.Architectures["assignments"]["rtl"]
+
+    def test_ConcurrentConditionalSignalAssignment(self) -> None:
+        """``s <= '1' when sel = 0 else '0' when sel = 1 else 'Z';``"""
+        architecture = self._architecture()
+        statement = architecture.Statements[0]
+
+        self.assertIsInstance(statement, ConcurrentConditionalSignalAssignment)
+        self.assertEqual(3, len(statement.ConditionalWaveforms))
+        self.assertIsNotNone(statement.ConditionalWaveforms[0].Condition)
+        self.assertIsNone(statement.ConditionalWaveforms[-1].Condition)
+
+    def test_ConcurrentSelectedSignalAssignment(self) -> None:
+        """``with sel select s2 <= '1' when 0 | 1, '0' when 2, 'Z' when others;`` - includes a
+        grouped choice ('0 | 1')."""
+        architecture = self._architecture()
+        statement = architecture.Statements[1]
+
+        self.assertIsInstance(statement, ConcurrentSelectedSignalAssignment)
+        self.assertEqual(3, len(statement.SelectedWaveforms))
+
+        grouped = statement.SelectedWaveforms[0]
+        self.assertIsInstance(grouped, SelectedWaveform)
+        self.assertEqual(2, len(grouped.Choices))
+
+        self.assertIsInstance(statement.SelectedWaveforms[-1], OthersSelectedWaveform)
+
+    def test_SequentialVariableAssignment(self) -> None:
+        """``v := '1';``"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[0]
+
+        self.assertIsInstance(statement, SequentialVariableAssignment)
+        self.assertIsNotNone(statement.Expression)
+
+    def test_SequentialConditionalVariableAssignment(self) -> None:
+        """``v2 := '1' when sel = 0 else '0' when sel = 1 else 'Z';`` (VHDL-2008)"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[1]
+
+        self.assertIsInstance(statement, SequentialConditionalVariableAssignment)
+        self.assertEqual(3, len(statement.ConditionalExpressions))
+        self.assertIsNone(statement.ConditionalExpressions[-1].Condition)
+
+    def test_SequentialConditionalSignalAssignment(self) -> None:
+        """``s <= '1' when sel = 0 else '0';`` (sequential form, VHDL-2008)"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[2]
+
+        self.assertIsInstance(statement, SequentialConditionalSignalAssignment)
+        self.assertEqual(2, len(statement.ConditionalWaveforms))
+
+    def test_SequentialSelectedVariableAssignment(self) -> None:
+        """``with sel select v := '1' when 0, '0' when others;``"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[3]
+
+        self.assertIsInstance(statement, SequentialSelectedVariableAssignment)
+        self.assertEqual(2, len(statement.SelectedExpressions))
+        self.assertIsInstance(statement.SelectedExpressions[0], SelectedExpression)
+        self.assertIsInstance(statement.SelectedExpressions[-1], OthersSelectedExpression)
+
+    def test_SequentialSelectedSignalAssignment(self) -> None:
+        """``with sel select s <= '1' when 0, '0' when others;`` (sequential form)"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[4]
+
+        self.assertIsInstance(statement, SequentialSelectedSignalAssignment)
+        self.assertEqual(2, len(statement.SelectedWaveforms))
+
+    def test_SignalForceAssignment(self) -> None:
+        """``s <= force '1';`` (VHDL-2008)"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[5]
+
+        self.assertIsInstance(statement, SignalForceAssignment)
+        self.assertIsNotNone(statement.Expression)
+
+    def test_SignalReleaseAssignment(self) -> None:
+        """``s <= release;`` (VHDL-2008)"""
+        process = self._architecture().Statements[2]
+        statement = process.Statements[6]
+
+        self.assertIsInstance(statement, SignalReleaseAssignment)
+        self.assertIsNotNone(statement.Target)

--- a/testsuite/pyunit/dom/Assignments.py
+++ b/testsuite/pyunit/dom/Assignments.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from unittest import TestCase
 
 from pyGHDL.dom.NonStandard import Design, Document
+from pyGHDL.dom.Symbol import SignalSymbol, VariableSymbol
 from pyGHDL.dom.Concurrent import ConcurrentConditionalSignalAssignment, ConcurrentSelectedSignalAssignment
 from pyGHDL.dom.Concurrent import SelectedWaveform, OthersSelectedWaveform
 from pyGHDL.dom.Sequential import (
@@ -74,6 +75,7 @@ class Assignments(TestCase):
         statement = architecture.Statements[0]
 
         self.assertIsInstance(statement, ConcurrentConditionalSignalAssignment)
+        self.assertIsInstance(statement.Target, SignalSymbol)
         self.assertEqual(3, len(statement.ConditionalWaveforms))
         self.assertIsNotNone(statement.ConditionalWaveforms[0].Condition)
         self.assertIsNone(statement.ConditionalWaveforms[-1].Condition)
@@ -85,6 +87,7 @@ class Assignments(TestCase):
         statement = architecture.Statements[1]
 
         self.assertIsInstance(statement, ConcurrentSelectedSignalAssignment)
+        self.assertIsInstance(statement.Target, SignalSymbol)
         self.assertEqual(3, len(statement.SelectedWaveforms))
 
         grouped = statement.SelectedWaveforms[0]
@@ -99,6 +102,7 @@ class Assignments(TestCase):
         statement = process.Statements[0]
 
         self.assertIsInstance(statement, SequentialVariableAssignment)
+        self.assertIsInstance(statement.Target, VariableSymbol)
         self.assertIsNotNone(statement.Expression)
 
     def test_SequentialConditionalVariableAssignment(self) -> None:
@@ -107,6 +111,7 @@ class Assignments(TestCase):
         statement = process.Statements[1]
 
         self.assertIsInstance(statement, SequentialConditionalVariableAssignment)
+        self.assertIsInstance(statement.Target, VariableSymbol)
         self.assertEqual(3, len(statement.ConditionalExpressions))
         self.assertIsNone(statement.ConditionalExpressions[-1].Condition)
 
@@ -116,6 +121,7 @@ class Assignments(TestCase):
         statement = process.Statements[2]
 
         self.assertIsInstance(statement, SequentialConditionalSignalAssignment)
+        self.assertIsInstance(statement.Target, SignalSymbol)
         self.assertEqual(2, len(statement.ConditionalWaveforms))
 
     def test_SequentialSelectedVariableAssignment(self) -> None:
@@ -124,6 +130,7 @@ class Assignments(TestCase):
         statement = process.Statements[3]
 
         self.assertIsInstance(statement, SequentialSelectedVariableAssignment)
+        self.assertIsInstance(statement.Target, VariableSymbol)
         self.assertEqual(2, len(statement.SelectedExpressions))
         self.assertIsInstance(statement.SelectedExpressions[0], SelectedExpression)
         self.assertIsInstance(statement.SelectedExpressions[-1], OthersSelectedExpression)
@@ -134,6 +141,7 @@ class Assignments(TestCase):
         statement = process.Statements[4]
 
         self.assertIsInstance(statement, SequentialSelectedSignalAssignment)
+        self.assertIsInstance(statement.Target, SignalSymbol)
         self.assertEqual(2, len(statement.SelectedWaveforms))
 
     def test_SignalForceAssignment(self) -> None:
@@ -142,6 +150,7 @@ class Assignments(TestCase):
         statement = process.Statements[5]
 
         self.assertIsInstance(statement, SignalForceAssignment)
+        self.assertIsInstance(statement.Target, SignalSymbol)
         self.assertIsNotNone(statement.Expression)
 
     def test_SignalReleaseAssignment(self) -> None:
@@ -150,4 +159,4 @@ class Assignments(TestCase):
         statement = process.Statements[6]
 
         self.assertIsInstance(statement, SignalReleaseAssignment)
-        self.assertIsNotNone(statement.Target)
+        self.assertIsInstance(statement.Target, SignalSymbol)

--- a/testsuite/pyunit/dom/Sequential.py
+++ b/testsuite/pyunit/dom/Sequential.py
@@ -74,10 +74,15 @@ class LoopConditions(TestCase):
         process = architecture.Statements[0]
         loop = process.Statements[0]
 
-        exitStatement, nextStatement = loop.Statements
+        exitStatement, nextStatement, variableAssignment = loop.Statements
 
         self.assertIsInstance(exitStatement, ExitStatement)
         self.assertIsNotNone(exitStatement.Condition)
 
         self.assertIsInstance(nextStatement, NextStatement)
         self.assertIsNotNone(nextStatement.Condition)
+
+        # Regression check: 'i := i + 1;' was previously silently dropped (warn-only), not even
+        # appearing in loop.Statements at all.
+        from pyGHDL.dom.Sequential import SequentialVariableAssignment
+        self.assertIsInstance(variableAssignment, SequentialVariableAssignment)

--- a/testsuite/pyunit/dom/examples/Assignments.vhdl
+++ b/testsuite/pyunit/dom/examples/Assignments.vhdl
@@ -1,0 +1,44 @@
+-- Author: Patrick Lehmann
+--
+-- Conditional/selected/force/release assignment statements: previously the only gap remaining in
+-- both the concurrent and sequential statement dispatchers (confirmed by a full audit before
+-- starting this work).
+entity Assignments is
+end entity Assignments;
+
+architecture rtl of Assignments is
+	signal s, s2 : bit;
+	signal sel : integer;
+begin
+	-- concurrent conditional signal assignment
+	s <= '1' when sel = 0 else '0' when sel = 1 else 'Z';
+
+	-- concurrent selected signal assignment, including a grouped choice ('0 | 1')
+	with sel select
+		s2 <= '1' when 0 | 1, '0' when 2, 'Z' when others;
+
+	process is
+		variable v, v2 : bit;
+	begin
+		-- sequential simple variable assignment
+		v := '1';
+
+		-- sequential conditional variable assignment (VHDL-2008)
+		v2 := '1' when sel = 0 else '0' when sel = 1 else 'Z';
+
+		-- sequential conditional signal assignment (VHDL-2008)
+		s <= '1' when sel = 0 else '0';
+
+		-- sequential selected variable assignment (VHDL-2008)
+		with sel select
+			v := '1' when 0, '0' when others;
+
+		-- sequential selected signal assignment
+		with sel select
+			s <= '1' when 0, '0' when others;
+
+		-- force/release (VHDL-2008)
+		s <= force '1';
+		s <= release;
+	end process;
+end architecture rtl;


### PR DESCRIPTION
## Summary

Companion to VHDL/pyVHDLModel#138. Covers the last remaining gap in both the concurrent and
sequential statement dispatchers (confirmed by a full audit before starting) -
`Concurrent_Conditional_Signal_Assignment`/`Concurrent_Selected_Signal_Assignment` were warn-only;
`Variable_Assignment_Statement`/`Conditional_Variable_Assignment_Statement`/
`Conditional_Signal_Assignment_Statement` were bundled into one warn-only branch;
`Selected_Variable_Assignment_Statement`/`Selected_Waveform_Assignment_Statement`/
`Signal_Force_Assignment_Statement`/`Signal_Release_Assignment_Statement` were entirely unhandled
(hard crash).

## Changes

- `pyGHDL/dom/Concurrent.py`: `ConditionalWaveform`, `SelectedWaveform`/`OthersSelectedWaveform` (+
  shared helpers `GetConditionalWaveformsFromChainedNodes`/`GetSelectedWaveformsFromChainedNodes`,
  reused by the sequential side too since GHDL uses the identical field structure for both), plus
  the two concrete concurrent assignment classes.
- `pyGHDL/dom/Sequential.py`: `ConditionalExpression`, `SelectedExpression`/
  `OthersSelectedExpression` (+ `GetConditionalExpressionsFromChainedNodes`/
  `GetSelectedExpressionsFromChainedNodes`), plus all 7 sequential assignment statement classes.

## A finding worth flagging

Multi-choice grouping (e.g. `when 0 | 1 =>`) required getting `Get_Same_Alternative_Flag`'s exact
semantics right rather than assuming they'd mirror the object/interface-declaration pattern used
elsewhere in this file - verified empirically first: the *first* choice in a group owns the real
associated content (`Same_Alternative_Flag=False`), later choices in the same group
(`Same_Alternative_Flag=True`) have a null associated chain and just contribute an additional
choice value. My first implementation assumed the opposite and was wrong; caught by testing
directly against real GHDL rather than trusting the analogy, and now mirrors exactly how the
case-generate `0 | 1 =>` grouping logic already elsewhere in this file works.

## Test fixture side effect

Updated `testsuite/pyunit/dom/Sequential.py::LoopConditions::test_ExitAndNextConditions`:
`i := i + 1;` inside the while loop was previously silently dropped (warn-only) and didn't appear
in `loop.Statements` at all - now correctly translated as a third statement, so the test's
tuple-unpack needed updating (and now also checks that statement explicitly).

## Testing

Verified against real GHDL analysis (nightly libghdl build) with all 9 statement kinds, including
the `0 | 1` grouped-choice case for both the selected-waveform and selected-expression paths.

Added `testsuite/pyunit/dom/Assignments.py` + `examples/Assignments.vhdl`. Full suite:
`69 passed` (was 60), 5 skipped, no regressions.

## Dependency

Requires https://github.com/VHDL/pyVHDLModel/pull/138 (open).
